### PR TITLE
Restyle buy steps section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -155,12 +155,167 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:980px){.grid.cols-3{grid-template-columns:1fr 1fr}}
 @media (max-width:720px){.grid.cols-3,.grid.cols-2{grid-template-columns:1fr}}
 
-.card{
+.card{ 
   background:linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.03));
   border:var(--border);border-radius:18px;padding:22px;box-shadow:var(--shadow);
  position:relative;overflow:hidden}
 .card h3{margin-top:0}
 .card .muted{color:var(--muted)}
+
+#buy{
+  background:
+    radial-gradient(900px 520px at 80% -10%, rgba(123,92,255,0.18) 0%, transparent 60%),
+    radial-gradient(820px 500px at -10% 20%, rgba(255,46,106,0.22) 0%, transparent 55%),
+    linear-gradient(160deg, rgba(15,12,27,0.95), rgba(10,9,20,0.92));
+}
+
+.buy-grid{
+  display:grid;
+  grid-template-columns:repeat(6,minmax(0,1fr));
+  gap:26px;
+  margin-top:34px;
+}
+
+.buy-card{
+  position:relative;
+  grid-column:span 2;
+  background:linear-gradient(185deg, rgba(22,18,40,0.95), rgba(15,13,32,0.88));
+  border:1px solid rgba(255,255,255,0.12);
+  border-radius:24px;
+  box-shadow:0 18px 40px rgba(4,3,15,0.55);
+  overflow:hidden;
+  display:flex;
+  flex-direction:column;
+  padding:26px;
+  isolation:isolate;
+  transition:transform .35s ease, box-shadow .35s ease;
+}
+
+.buy-card::after{
+  content:"";
+  position:absolute;
+  inset:auto -20% -55% -20%;
+  background:radial-gradient(circle at 50% 0%, rgba(123,92,255,0.45), transparent 70%);
+  opacity:0;
+  transition:opacity .35s ease;
+  pointer-events:none;
+}
+
+.buy-card:hover{
+  transform:translateY(-6px);
+  box-shadow:0 26px 58px rgba(8,5,28,0.65);
+}
+
+.buy-card:hover::after{opacity:1;}
+
+.buy-card--wide{
+  grid-column:span 3;
+  flex-direction:row;
+  gap:24px;
+  padding:28px;
+}
+
+.buy-card--wide .buy-card__media{
+  flex:0 0 44%;
+  min-height:100%;
+}
+
+.buy-card--wide .buy-card__content{
+  justify-content:center;
+}
+
+.buy-card__media{
+  position:relative;
+  border-radius:20px;
+  overflow:hidden;
+  min-height:160px;
+  background:rgba(18,16,34,0.9);
+  flex:0 0 auto;
+  width:100%;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.08);
+}
+
+.buy-card__media::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(180deg, rgba(10,8,24,0) 0%, rgba(10,8,24,0.65) 100%);
+  z-index:1;
+}
+
+.buy-card__media img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+  filter:saturate(1.05) contrast(1.05);
+}
+
+.buy-card__content{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  z-index:1;
+}
+
+.buy-card__step{
+  display:inline-flex;
+  align-self:flex-start;
+  padding:6px 14px;
+  border-radius:999px;
+  background:rgba(255,255,255,0.06);
+  border:1px solid rgba(255,255,255,0.14);
+  font-weight:700;
+  font-size:13px;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#fff;
+}
+
+.buy-card__title{
+  margin:0;
+  font-size:22px;
+  line-height:1.2;
+}
+
+.buy-card__text{
+  margin:0;
+  color:var(--muted);
+  line-height:1.55;
+  font-size:15px;
+}
+
+.buy-note{
+  margin-top:32px;
+  padding:22px 26px;
+  border-radius:20px;
+  background:rgba(255,46,106,0.08);
+  border:1px solid rgba(255,46,106,0.25);
+  box-shadow:0 16px 40px rgba(255,46,106,0.12);
+  color:#ffb8cd;
+  font-size:15px;
+  line-height:1.6;
+}
+
+.buy-note strong{color:#ffd9e6;font-weight:700;}
+
+@media (max-width:1280px){
+  .buy-grid{grid-template-columns:repeat(4,minmax(0,1fr));}
+  .buy-card--wide{grid-column:span 4;flex-direction:column;}
+  .buy-card--wide .buy-card__media{flex:0 0 auto;min-height:200px;}
+}
+
+@media (max-width:960px){
+  .buy-grid{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .buy-card,.buy-card--wide{grid-column:auto;}
+}
+
+@media (max-width:720px){
+  .buy-grid{grid-template-columns:1fr;gap:22px;}
+  .buy-card{padding:22px;}
+  .buy-card--wide{padding:24px;}
+  .buy-card__media{min-height:180px;}
+}
 
 .idea-grid{gap:28px}
 .idea-card{

--- a/index.html
+++ b/index.html
@@ -124,16 +124,62 @@
   <section id="buy" class="reveal">
     <div class="container">
       <h2 class="section-title">Пять шагов к $RAKODI</h2>
-      <div class="grid cols-3">
-        <div class="card"><h3>I — Подключи кошелёк</h3><p class="muted">Подходит WalletConnect/поддерживаемые кошельки.</p></div>
-        <div class="card"><h3>II — Выбери $RAKODI</h3><p class="muted">Убедись, что это наш тикер.</p></div>
-        <div class="card"><h3>III — Проверь адрес</h3><p class="muted">Сверь с адресом на этой странице. Не доверяй сторонним ссылкам.</p></div>
-        <div class="card"><h3>IV — Совершай своп</h3><p class="muted">Выбери желаемый объём, подтверди транзакцию.</p></div>
-        <div class="card"><h3>V — Добавь токен</h3><p class="muted">Чтобы видеть баланс и сделки.</p></div>
+      <p class="section-sub">Следуй чек-листу, чтобы безопасно подключиться, найти наш токен и завершить сделку без лишнего риска.</p>
+      <div class="buy-grid">
+        <article class="buy-card buy-card--wide">
+          <div class="buy-card__media">
+            <img src="assets/buy/step-1-connect.jpg" alt="Подключение кошелька к платформе" loading="lazy">
+          </div>
+          <div class="buy-card__content">
+            <span class="buy-card__step">Шаг I</span>
+            <h3 class="buy-card__title">Подключи кошелёк</h3>
+            <p class="buy-card__text">Открой WalletConnect или поддерживаемый кошелёк, подтверди доступ к сети и создай безопасное подключение к памфану.</p>
+          </div>
+        </article>
+        <article class="buy-card buy-card--wide">
+          <div class="buy-card__media">
+            <img src="assets/buy/step-2-ticker.jpg" alt="Выбор токена RAKODI в интерфейсе" loading="lazy">
+          </div>
+          <div class="buy-card__content">
+            <span class="buy-card__step">Шаг II</span>
+            <h3 class="buy-card__title">Выбери $RAKODI</h3>
+            <p class="buy-card__text">В поиске укажи тикер $RAKODI. Сверь визуальные элементы и описание, чтобы исключить фейковые токены.</p>
+          </div>
+        </article>
+        <article class="buy-card">
+          <div class="buy-card__media">
+            <img src="assets/buy/step-3-address.jpg" alt="Проверка официального адреса токена" loading="lazy">
+          </div>
+          <div class="buy-card__content">
+            <span class="buy-card__step">Шаг III</span>
+            <h3 class="buy-card__title">Проверь адрес</h3>
+            <p class="buy-card__text">Скопируй адрес контракта с этой страницы и сравни с тем, что видишь в интерфейсе обмена. Не переходи по сторонним ссылкам.</p>
+          </div>
+        </article>
+        <article class="buy-card">
+          <div class="buy-card__media">
+            <img src="assets/buy/step-4-swap.jpg" alt="Окно подтверждения свопа" loading="lazy">
+          </div>
+          <div class="buy-card__content">
+            <span class="buy-card__step">Шаг IV</span>
+            <h3 class="buy-card__title">Совершай своп</h3>
+            <p class="buy-card__text">Выставь желаемый объём, проверь комиссии и подтвердите транзакцию. Дождись статуса «успешно» в кошельке.</p>
+          </div>
+        </article>
+        <article class="buy-card">
+          <div class="buy-card__media">
+            <img src="assets/buy/step-5-track.jpg" alt="Мониторинг баланса после покупки" loading="lazy">
+          </div>
+          <div class="buy-card__content">
+            <span class="buy-card__step">Шаг V</span>
+            <h3 class="buy-card__title">Добавь токен</h3>
+            <p class="buy-card__text">Импортируй адрес контракта в кошелёк, чтобы отслеживать баланс и историю сделок прямо в приложении.</p>
+          </div>
+        </article>
       </div>
-      <div class="card" style="margin-top:12px">
-        <b>Важно:</b> Крипто — риск. Делай собственное исследование (DYOR). Ничто на сайте не является инвестсоветом.
-      </div>
+      <aside class="buy-note">
+        <strong>Важно:</strong> крипторынок волатилен. Делай собственное исследование (DYOR) и инвестируй только те средства, которые готов рискнуть.
+      </aside>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- restructure the buy section into a two-row card layout with imagery placeholders to mirror the reference structure
- add bespoke styling for the new layout, responsive behavior, and an accentuated DYOR safety note that matches the existing aesthetic

## Testing
- not run (static HTML/CSS site)


------
https://chatgpt.com/codex/tasks/task_e_68d13ea4b584832ab69d2f38bec06b1a