### PR TITLE
Redesign quests block with infographic styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -222,13 +222,111 @@
       </div></section>
 
   <!-- 8) Награды и квесты — «Играй по‑серьёзному» -->
-  <section id="quests" class="reveal">
+  <section id="quests" class="reveal quest-section">
     <div class="container">
-      <h2 class="section-title">Квесты Братства</h2>
-      <div class="grid cols-3">
-        <div class="card"><h3>I — Огонь форума</h3><p class="muted">Подпишись на YouTube и оставь осмысленный комментарий к последнему тизеру.</p><p class="small"><b>Награда:</b> бэйдж «Новобранец», очки сезонного рейтинга.</p></div>
-        <div class="card"><h3>II — Свиток дня</h3><p class="muted">Опубликуй мем/гайд в библиотеку по правилам.</p><p class="small"><b>Награда:</b> повышенные очки, шанс попасть в видео.</p></div>
-        <div class="card"><h3>III — Голос Консула</h3><p class="muted">Прими участие в голосовании по фичам/приоритетам.</p><p class="small"><b>Награда:</b> бэйдж «Смотритель», влияние в обсуждениях.</p></div>
+      <div class="quest-header">
+        <div class="quest-text">
+          <h2 class="section-title">Квесты Братства</h2>
+          <p class="section-sub">Практика, которая превращает зрителей в создателей. Выполняй задания — получай роли и голос.</p>
+          <div class="quest-meta">
+            <span class="quest-pill">Игровые и медиа‑квесты</span>
+            <span class="quest-pill">Награды за вклад</span>
+            <span class="quest-pill quest-pill-glow">Обновление каждую пятницу</span>
+          </div>
+        </div>
+        <div class="quest-infographic" aria-hidden="true">
+          <div class="quest-radial-wrapper" style="--progress:0.58">
+            <svg class="quest-radial" viewBox="0 0 160 160" role="presentation" focusable="false">
+              <defs>
+                <linearGradient id="quest-progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#ff2e6a" />
+                  <stop offset="100%" stop-color="#7b5cff" />
+                </linearGradient>
+              </defs>
+              <circle class="quest-ring-bg" cx="80" cy="80" r="68"></circle>
+              <circle class="quest-ring-active" cx="80" cy="80" r="68"></circle>
+            </svg>
+            <div class="quest-radial-value">
+              <span class="quest-radial-number">58%</span>
+              <span class="quest-radial-label">комьюнити вовлечено</span>
+            </div>
+          </div>
+          <div class="quest-infographic-caption">
+            <span class="metric-title">Вклад недели</span>
+            <span class="metric-delta">+210 выполненных миссий</span>
+            <span class="metric-sub">данные за 7 последних дней</span>
+          </div>
+        </div>
+      </div>
+      <div class="quest-grid">
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🔥"></span>
+            <span class="quest-tier">Этап I</span>
+          </div>
+          <h3>Огонь форума</h3>
+          <p class="muted">Подпишись на YouTube и оставь осмысленный комментарий к последнему тизеру.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Новобранец» и очки сезонного рейтинга</span>
+          </div>
+          <div class="quest-progress" data-label="онбординг">
+            <div class="quest-progress-bar" style="--progress:0.6"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="📜"></span>
+            <span class="quest-tier">Этап II</span>
+          </div>
+          <h3>Свиток дня</h3>
+          <p class="muted">Опубликуй мем или гайд в библиотеку по правилам и помоги другим с ревью.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Повышенные очки, шанс попасть в видео</span>
+          </div>
+          <div class="quest-progress" data-label="контент">
+            <div class="quest-progress-bar" style="--progress:0.5"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🎙️"></span>
+            <span class="quest-tier">Этап III</span>
+          </div>
+          <h3>Голос Консула</h3>
+          <p class="muted">Прими участие в голосовании по фичам и стратегическим приоритетам.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Смотритель» и влияние в обсуждениях</span>
+          </div>
+          <div class="quest-progress" data-label="governance">
+            <div class="quest-progress-bar" style="--progress:0.42"></div>
+          </div>
+        </article>
+      </div>
+      <div class="quest-footer">
+        <div class="quest-leaderboard card">
+          <div class="quest-leaderboard-head">
+            <h4>Топ‑5 недели</h4>
+            <span class="leaderboard-period">обновление: пятница</span>
+          </div>
+          <ul>
+            <li><span class="place">#1</span><span class="name">[ник]</span><span class="points">1280</span></li>
+            <li><span class="place">#2</span><span class="name">[ник]</span><span class="points">1120</span></li>
+            <li><span class="place">#3</span><span class="name">[ник]</span><span class="points">980</span></li>
+            <li><span class="place">#4</span><span class="name">[ник]</span><span class="points">860</span></li>
+            <li><span class="place">#5</span><span class="name">[ник]</span><span class="points">790</span></li>
+          </ul>
+        </div>
+        <div class="quest-cta card">
+          <h4>Забери первый бэйдж</h4>
+          <p class="muted">Нажми старт, пройди онбординг и получи доступ к закрытым каналам и бонусным миссиям.</p>
+          <div class="hero-cta">
+            <a href="#" class="btn">Стартовать</a>
+            <a href="#" class="btn ghost">Правила участия</a>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/brotherhood.html
+++ b/brotherhood.html
@@ -123,19 +123,112 @@
   </section>
 
   <!-- 6) Квесты и награды -->
-  <section id="quests" class="reveal">
+  <section id="quests" class="reveal quest-section">
     <div class="container">
-      <h2 class="section-title">Квесты Братства</h2>
-      <div class="grid cols-3">
-        <div class="card"><h3>I — Огонь форума</h3><p class="muted">Подпишись на YouTube и оставь осмысленный комментарий к последнему тизеру.</p><p class="small"><b>Награда:</b> бэйдж «Новобранец», очки сезона.</p></div>
-        <div class="card"><h3>II — Свиток дня</h3><p class="muted">Опубликуй мем/гайд по правилам, помоги с обратной связью другим.</p><p class="small"><b>Награда:</b> очки, шанс на витрину и упоминание в ролике.</p></div>
-        <div class="card"><h3>III — Голос Консула</h3><p class="muted">Поучаствуй в опросах/голосовании по фичам и приоритетам недели.</p><p class="small"><b>Награда:</b> бэйдж «Смотритель», повышение веса голоса.</p></div>
-      </div>
-      <div class="card" style="padding:12px;margin-top:10px">
-        <div style="height:8px;border-radius:8px;background:var(--glass);border:var(--border);overflow:hidden">
-          <div style="height:100%;width:40%;background:linear-gradient(90deg,var(--accent),var(--accent-2));"></div>
+      <div class="quest-header">
+        <div class="quest-text">
+          <h2 class="section-title">Квесты Братства</h2>
+          <p class="section-sub">Ступени посвящения от базовой искры до совета Консулов. Выбирай, что ближе к твоему навыку.</p>
+          <div class="quest-meta">
+            <span class="quest-pill">Сезонные рейтинги</span>
+            <span class="quest-pill">+5 новых заданий</span>
+            <span class="quest-pill quest-pill-glow">Текущий этап: «Памфан»</span>
+          </div>
         </div>
-        <p class="small" style="margin:6px 0 0">Рейтинги — сезонные. Лучшие получают особые упоминания и ролики‑кредиты.</p>
+        <div class="quest-infographic" aria-hidden="true">
+          <div class="quest-radial-wrapper" style="--progress:0.4">
+            <svg class="quest-radial" viewBox="0 0 160 160" role="presentation" focusable="false">
+              <defs>
+                <linearGradient id="quest-progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#ff2e6a" />
+                  <stop offset="100%" stop-color="#7b5cff" />
+                </linearGradient>
+              </defs>
+              <circle class="quest-ring-bg" cx="80" cy="80" r="68"></circle>
+              <circle class="quest-ring-active" cx="80" cy="80" r="68"></circle>
+            </svg>
+            <div class="quest-radial-value">
+              <span class="quest-radial-number">40%</span>
+              <span class="quest-radial-label">завершено</span>
+            </div>
+          </div>
+          <div class="quest-infographic-caption">
+            <span class="metric-title">Сезонный прогресс</span>
+            <span class="metric-delta">+8% за неделю</span>
+            <span class="metric-sub">лучшие получают кредиты в роликах</span>
+          </div>
+        </div>
+      </div>
+      <div class="quest-grid">
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🔥"></span>
+            <span class="quest-tier">I ступень</span>
+          </div>
+          <h3>Огонь форума</h3>
+          <p class="muted">Подпишись на YouTube и оставь осмысленный комментарий к последнему тизеру.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Новобранец» + очки сезона</span>
+          </div>
+          <div class="quest-progress" data-label="комьюнити">
+            <div class="quest-progress-bar" style="--progress:0.55"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="📜"></span>
+            <span class="quest-tier">II ступень</span>
+          </div>
+          <h3>Свиток дня</h3>
+          <p class="muted">Опубликуй мем или гайд по правилам, помоги с обратной связью другим.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Очки, шанс на витрину и упоминание в ролике</span>
+          </div>
+          <div class="quest-progress" data-label="мем-библиотека">
+            <div class="quest-progress-bar" style="--progress:0.47"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🎙️"></span>
+            <span class="quest-tier">III ступень</span>
+          </div>
+          <h3>Голос Консула</h3>
+          <p class="muted">Поучаствуй в голосовании по фичам и приоритетам недели.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Смотритель» + усиленный вес голоса</span>
+          </div>
+          <div class="quest-progress" data-label="governance">
+            <div class="quest-progress-bar" style="--progress:0.33"></div>
+          </div>
+        </article>
+      </div>
+      <div class="quest-footer">
+        <div class="quest-leaderboard card">
+          <div class="quest-leaderboard-head">
+            <h4>Рейтинг сезона</h4>
+            <span class="leaderboard-period">обновляется еженедельно</span>
+          </div>
+          <ul>
+            <li><span class="place">#1</span><span class="name">[ник]</span><span class="points">1280</span></li>
+            <li><span class="place">#2</span><span class="name">[ник]</span><span class="points">1120</span></li>
+            <li><span class="place">#3</span><span class="name">[ник]</span><span class="points">980</span></li>
+            <li><span class="place">#4</span><span class="name">[ник]</span><span class="points">860</span></li>
+            <li><span class="place">#5</span><span class="name">[ник]</span><span class="points">790</span></li>
+          </ul>
+          <p class="small">Лучшие попадают в спец‑ролики и получают кредиты в мем‑каноне.</p>
+        </div>
+        <div class="quest-cta card">
+          <h4>Выполни три шага</h4>
+          <p class="muted">Закрой первые квесты, чтобы получить доступ к Посвящённому братству и новым механикам.</p>
+          <div class="hero-cta">
+            <a href="#" class="btn">Открыть список</a>
+            <a href="#" class="btn ghost">Смотреть гайды</a>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/css/styles.css
+++ b/css/styles.css
@@ -155,12 +155,267 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:980px){.grid.cols-3{grid-template-columns:1fr 1fr}}
 @media (max-width:720px){.grid.cols-3,.grid.cols-2{grid-template-columns:1fr}}
 
-.card{ 
+.card{
   background:linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.03));
   border:var(--border);border-radius:18px;padding:22px;box-shadow:var(--shadow);
  position:relative;overflow:hidden}
 .card h3{margin-top:0}
 .card .muted{color:var(--muted)}
+
+.quest-section{
+  overflow:hidden;
+  background:
+    radial-gradient(1100px 600px at 20% 0%, rgba(123,92,255,0.16), transparent 65%),
+    radial-gradient(820px 520px at 90% 20%, rgba(255,46,106,0.14), transparent 72%);
+}
+.quest-section::before{
+  content:"";
+  position:absolute;
+  inset:auto -25% -45% -25%;
+  height:260px;
+  background:radial-gradient(circle at 50% 0%, rgba(123,92,255,0.25), transparent 70%);
+  opacity:.6;
+  pointer-events:none;
+  filter:blur(0.5px);
+}
+.quest-section .container{position:relative;z-index:1}
+
+.quest-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:36px;
+  flex-wrap:wrap;
+}
+.quest-text{flex:1;min-width:260px}
+.quest-meta{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
+.quest-pill{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 14px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:rgba(14,16,30,0.72);
+  box-shadow:inset 0 0 20px rgba(123,92,255,0.1);
+  font-size:13px;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#f0ecff;
+  opacity:.88;
+}
+.quest-pill::before{
+  content:"";
+  width:6px;height:6px;border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 12px rgba(123,92,255,0.7);
+}
+.quest-pill-glow{
+  background:linear-gradient(135deg,rgba(255,46,106,0.22),rgba(123,92,255,0.18));
+  box-shadow:0 0 22px rgba(123,92,255,0.35);
+}
+
+.quest-infographic{
+  display:flex;
+  align-items:center;
+  gap:18px;
+  min-width:240px;
+}
+.quest-radial-wrapper{
+  position:relative;
+  width:160px;
+  height:160px;
+  border-radius:50%;
+  display:grid;
+  place-items:center;
+  background:radial-gradient(circle at 30% 30%, rgba(123,92,255,0.28), rgba(14,14,28,0.6));
+  border:1px solid rgba(255,255,255,0.18);
+  box-shadow:0 18px 38px rgba(10,6,26,0.6);
+  isolation:isolate;
+}
+.quest-radial{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  transform:rotate(-90deg);
+}
+.quest-ring-bg{
+  fill:none;
+  stroke:rgba(255,255,255,0.12);
+  stroke-width:12;
+}
+.quest-ring-active{
+  fill:none;
+  stroke:url(#quest-progress-gradient);
+  stroke-width:12;
+  stroke-linecap:round;
+  stroke-dasharray:440;
+  stroke-dashoffset:calc(440 - 440 * var(--progress,0));
+  transition:stroke-dashoffset .6s ease;
+  filter:drop-shadow(0 0 14px rgba(123,92,255,0.45));
+}
+.quest-radial-value{
+  position:relative;
+  z-index:2;
+  text-align:center;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.quest-radial-number{font-size:32px;font-weight:800;line-height:1}
+.quest-radial-label{font-size:13px;text-transform:uppercase;letter-spacing:0.08em;color:rgba(236,231,255,0.65)}
+.quest-infographic-caption{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:14px;
+  color:rgba(236,231,255,0.86);
+}
+.quest-infographic-caption .metric-title{font-weight:700;text-transform:uppercase;letter-spacing:0.08em;font-size:12px;color:rgba(236,231,255,0.6)}
+.quest-infographic-caption .metric-delta{font-size:18px;font-weight:700;color:#f8f5ff}
+.quest-infographic-caption .metric-sub{font-size:12px;color:rgba(236,231,255,0.55);text-transform:uppercase;letter-spacing:0.06em}
+
+.quest-grid{
+  margin-top:42px;
+  display:grid;
+  gap:26px;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+}
+@media (max-width:980px){
+  .quest-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+@media (max-width:720px){
+  .quest-grid{grid-template-columns:1fr}
+}
+
+.quest-card{padding:28px;transition:transform .35s ease, box-shadow .35s ease}
+.quest-card::after{
+  content:"";
+  position:absolute;
+  inset:-40% -40% 40% -40%;
+  background:radial-gradient(circle at 50% 0%, rgba(123,92,255,0.3), transparent 65%);
+  opacity:0;
+  transition:opacity .35s ease;
+  pointer-events:none;
+}
+.quest-card:hover{transform:translateY(-6px)}
+.quest-card:hover::after{opacity:.75}
+.quest-card-top{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:18px;
+}
+.quest-icon{
+  width:52px;
+  height:52px;
+  border-radius:18px;
+  display:grid;
+  place-items:center;
+  background:radial-gradient(circle at 30% 30%, rgba(255,255,255,0.2), rgba(15,13,30,0.9));
+  box-shadow:inset 0 0 20px rgba(123,92,255,0.45),0 12px 20px rgba(8,5,20,0.55);
+}
+.quest-icon::before{content:attr(data-icon);font-size:26px;filter:drop-shadow(0 3px 8px rgba(0,0,0,0.4))}
+.quest-tier{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.1em;
+  color:rgba(236,231,255,0.7);
+  padding:6px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:rgba(12,11,24,0.8);
+}
+.quest-reward{
+  margin-top:20px;
+  padding:14px 16px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:rgba(13,12,26,0.7);
+  box-shadow:inset 0 0 18px rgba(123,92,255,0.12);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.quest-reward .label{font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:rgba(236,231,255,0.58)}
+.quest-reward .value{font-weight:600;color:#f6f3ff}
+.quest-progress{
+  margin-top:26px;
+  position:relative;
+  height:12px;
+  border-radius:999px;
+  background:rgba(236,231,255,0.1);
+  overflow:hidden;
+}
+.quest-progress::before{
+  content:attr(data-label);
+  position:absolute;
+  top:-26px;
+  left:0;
+  font-size:11px;
+  letter-spacing:0.12em;
+  text-transform:uppercase;
+  color:rgba(236,231,255,0.5);
+}
+.quest-progress-bar{
+  width:calc(100% * var(--progress,0));
+  height:100%;
+  border-radius:inherit;
+  background:linear-gradient(90deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 18px rgba(123,92,255,0.55);
+}
+
+.quest-footer{
+  margin-top:40px;
+  display:grid;
+  grid-template-columns:minmax(0,1.4fr) minmax(0,1fr);
+  gap:26px;
+  align-items:stretch;
+}
+.quest-leaderboard{padding:26px 28px;display:flex;flex-direction:column;gap:18px}
+.quest-leaderboard-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.quest-leaderboard h4{margin:0;font-size:22px}
+.leaderboard-period{font-size:12px;text-transform:uppercase;letter-spacing:0.08em;color:rgba(236,231,255,0.6)}
+.quest-leaderboard ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:12px}
+.quest-leaderboard li{
+  display:grid;
+  grid-template-columns:40px 1fr 80px;
+  gap:12px;
+  align-items:center;
+  padding:10px 12px;
+  border-radius:12px;
+  background:rgba(15,13,30,0.65);
+  border:1px solid rgba(255,255,255,0.08);
+}
+.quest-leaderboard li .place{font-weight:700;color:#fdfbff}
+.quest-leaderboard li .points{font-weight:700;text-align:right;color:rgba(255,255,255,0.85)}
+.quest-leaderboard li .name{color:rgba(236,231,255,0.78)}
+.quest-leaderboard .small{margin:0;color:rgba(236,231,255,0.6)}
+.quest-cta{padding:28px 30px;display:flex;flex-direction:column;gap:18px;justify-content:space-between}
+.quest-cta h4{margin:0;font-size:24px}
+.quest-cta .hero-cta{justify-content:flex-start}
+.quest-cta .btn.ghost{background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.18)}
+
+@media (max-width:1020px){
+  .quest-infographic{width:100%}
+  .quest-infographic{justify-content:flex-start}
+}
+@media (max-width:880px){
+  .quest-footer{grid-template-columns:1fr}
+  .quest-leaderboard li{grid-template-columns:36px 1fr 70px}
+}
+@media (max-width:640px){
+  .quest-radial-wrapper{width:140px;height:140px}
+  .quest-radial-number{font-size:28px}
+  .quest-pill{font-size:12px}
+  .quest-cta .hero-cta{flex-wrap:wrap}
+}
+@media (max-width:540px){
+  .quest-leaderboard li{grid-template-columns:32px 1fr 60px;font-size:14px}
+  .quest-progress::before{font-size:10px}
+}
 
 #buy{
   background:

--- a/index.html
+++ b/index.html
@@ -210,17 +210,112 @@
   </section>
 
   <!-- Награды и квесты -->
-  <section id="quests" class="reveal">
+  <section id="quests" class="reveal quest-section">
     <div class="container">
-      <h2 class="section-title">Квесты Братства</h2>
-      <p class="section-sub">Играй по-серьёзному. Создавай мемы, помогай сообществу — поднимайся по рангу.</p>
-      <div class="grid cols-3">
-        <div class="card"><h3>Огонь форума</h3><p class="muted">Подписка на YouTube + первый комментарий под тизером.</p><p class="small">Награда: Бэйдж «Новобранец» + [X] очков.</p></div>
-        <div class="card"><h3>Свиток дня</h3><p class="muted">Опубликуй мем в библиотеку (с правилами). Лучшие — на главной.</p><p class="small">Награда: Бэйдж «Смотритель» + [X] очков.</p></div>
-        <div class="card"><h3>Голос Консула</h3><p class="muted">Участие в голосовании по фичам/листингу.</p><p class="small">Награда: Бэйдж «Архивариус» + [X] очков.</p></div>
+      <div class="quest-header">
+        <div class="quest-text">
+          <h2 class="section-title">Квесты Братства</h2>
+          <p class="section-sub">Играй по-серьёзному. Создавай мемы, помогай сообществу — поднимайся по рангу.</p>
+          <div class="quest-meta">
+            <span class="quest-pill">12 активных заданий</span>
+            <span class="quest-pill">+320 участников недели</span>
+            <span class="quest-pill quest-pill-glow">Сезон «Origin»</span>
+          </div>
+        </div>
+        <div class="quest-infographic" aria-hidden="true">
+          <div class="quest-radial-wrapper" style="--progress:0.72">
+            <svg class="quest-radial" viewBox="0 0 160 160" role="presentation" focusable="false">
+              <defs>
+                <linearGradient id="quest-progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#ff2e6a" />
+                  <stop offset="100%" stop-color="#7b5cff" />
+                </linearGradient>
+              </defs>
+              <circle class="quest-ring-bg" cx="80" cy="80" r="68"></circle>
+              <circle class="quest-ring-active" cx="80" cy="80" r="68"></circle>
+            </svg>
+            <div class="quest-radial-value">
+              <span class="quest-radial-number">72%</span>
+              <span class="quest-radial-label">прогресс сезона</span>
+            </div>
+          </div>
+          <div class="quest-infographic-caption">
+            <span class="metric-title">Боевой дух</span>
+            <span class="metric-delta">+12% за неделю</span>
+            <span class="metric-sub">обновляется каждые 24 ч</span>
+          </div>
+        </div>
       </div>
-      <div class="card" style="margin-top:12px"><b>Топ‑5 недели:</b> [ник — очки]</div>
-      <div class="hero-cta"><a href="#" class="btn">Начать первый квест</a></div>
+      <div class="quest-grid">
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🔥"></span>
+            <span class="quest-tier">Ранг I</span>
+          </div>
+          <h3>Огонь форума</h3>
+          <p class="muted">Подписка на YouTube + первый комментарий под тизером.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Новобранец» + <strong>[X]</strong> очков</span>
+          </div>
+          <div class="quest-progress" data-label="социальный импульс">
+            <div class="quest-progress-bar" style="--progress:0.45"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="📜"></span>
+            <span class="quest-tier">Ранг II</span>
+          </div>
+          <h3>Свиток дня</h3>
+          <p class="muted">Опубликуй мем в библиотеку (с правилами). Лучшие — на главной.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Смотритель» + <strong>[X]</strong> очков</span>
+          </div>
+          <div class="quest-progress" data-label="медиатека">
+            <div class="quest-progress-bar" style="--progress:0.62"></div>
+          </div>
+        </article>
+        <article class="quest-card card">
+          <div class="quest-card-top">
+            <span class="quest-icon" data-icon="🎙️"></span>
+            <span class="quest-tier">Ранг III</span>
+          </div>
+          <h3>Голос Консула</h3>
+          <p class="muted">Участие в голосовании по фичам/листингу.</p>
+          <div class="quest-reward">
+            <span class="label">Награда</span>
+            <span class="value">Бэйдж «Архивариус» + <strong>[X]</strong> очков</span>
+          </div>
+          <div class="quest-progress" data-label="governance">
+            <div class="quest-progress-bar" style="--progress:0.38"></div>
+          </div>
+        </article>
+      </div>
+      <div class="quest-footer">
+        <div class="quest-leaderboard card">
+          <div class="quest-leaderboard-head">
+            <h4>Топ‑5 недели</h4>
+            <span class="leaderboard-period">обновление: пн 12:00 (UTC)</span>
+          </div>
+          <ul>
+            <li><span class="place">#1</span><span class="name">[ник]</span><span class="points">1280</span></li>
+            <li><span class="place">#2</span><span class="name">[ник]</span><span class="points">1120</span></li>
+            <li><span class="place">#3</span><span class="name">[ник]</span><span class="points">980</span></li>
+            <li><span class="place">#4</span><span class="name">[ник]</span><span class="points">860</span></li>
+            <li><span class="place">#5</span><span class="name">[ник]</span><span class="points">790</span></li>
+          </ul>
+        </div>
+        <div class="quest-cta card">
+          <h4>Начни путь героя</h4>
+          <p class="muted">Собери базовые задания, чтобы открыть секретные свитки и доступ к закрытым голосованиям.</p>
+          <div class="hero-cta">
+            <a href="#" class="btn">Войти в братство</a>
+            <a href="#" class="btn ghost">Смотреть награды</a>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- rebuild the "Квесты Братства" sections with a new layout featuring infographic stats, quest metadata, and richer card content
- add bespoke quest section styles including radial progress, leaderboard layout, and responsive tweaks to match the neon aesthetic
- apply the refreshed block across index, brotherhood, and about pages for a consistent presentation

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d145ed3494832a8b8338ad4f091c11