### PR TITLE
feat: redesign partners marquee

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -834,6 +834,155 @@ footer img{border-radius:12px;padding:0;background:transparent;border:none;filte
 /* hide overlapping center legend in memlib */
 #memlib .badge[style*='left:50%'][style*='top:50%']{display:none!important}
 
+.partners-marquee{
+  position:relative;
+  width:100vw;
+  margin-left:calc(50% - 50vw);
+  padding:clamp(28px,5vw,56px) 0;
+  border-top:1px solid rgba(123,92,255,0.28);
+  border-bottom:1px solid rgba(123,92,255,0.28);
+  background:linear-gradient(180deg, rgba(21,16,44,0.95) 0%, rgba(10,8,26,0.92) 55%, rgba(18,14,40,0.95) 100%);
+  box-shadow:inset 0 0 40px rgba(6,4,20,0.85);
+  overflow:hidden;
+}
+.partners-marquee::before,
+.partners-marquee::after{
+  content:"";
+  position:absolute;
+  top:0;
+  bottom:0;
+  width:16%;
+  pointer-events:none;
+  z-index:3;
+  background:linear-gradient(to right, rgba(9,7,20,0.92) 0%, rgba(9,7,20,0));
+}
+.partners-marquee::before{left:0;}
+.partners-marquee::after{right:0;transform:scaleX(-1);}
+
+.partners-row{
+  position:relative;
+  overflow:hidden;
+  margin-bottom:clamp(16px,3vw,30px);
+  mask-image:linear-gradient(to right, transparent 0%, #000 12%, #000 88%, transparent 100%);
+  -webkit-mask-image:linear-gradient(to right, transparent 0%, #000 12%, #000 88%, transparent 100%);
+}
+.partners-row:last-child{margin-bottom:0;}
+
+.partners-track{
+  display:flex;
+  align-items:stretch;
+  gap:clamp(16px,3vw,32px);
+  width:max-content;
+  will-change:transform;
+}
+.partners-track--left{animation:partners-marquee-left 34s linear infinite;}
+.partners-track--right{animation:partners-marquee-right 36s linear infinite;}
+.partners-track--slow{animation-duration:48s;}
+
+@keyframes partners-marquee-left{
+  from{transform:translateX(0);}
+  to{transform:translateX(-50%);}
+}
+@keyframes partners-marquee-right{
+  from{transform:translateX(-50%);}
+  to{transform:translateX(0);}
+}
+
+.partner-card{
+  position:relative;
+  flex:0 0 auto;
+  width:clamp(168px,18vw,240px);
+  aspect-ratio:3/2;
+  border-radius:18px;
+  overflow:hidden;
+  border:1px solid rgba(123,92,255,0.28);
+  background:linear-gradient(140deg, rgba(24,20,48,0.6), rgba(12,10,28,0.8));
+  box-shadow:0 26px 60px rgba(6,4,24,0.55);
+  transform-origin:center;
+  transition:transform .45s ease, box-shadow .45s ease;
+}
+.partner-card:hover,
+.partner-card:focus-within{
+  transform:translateY(-6px);
+  box-shadow:0 32px 72px rgba(6,4,24,0.7);
+}
+.partner-card img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+  filter:saturate(1.08) contrast(1.05);
+  transform:scale(1.02);
+}
+.partner-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  z-index:1;
+  background:linear-gradient(135deg, rgba(123,92,255,0.24), rgba(255,46,106,0.08));
+  mix-blend-mode:screen;
+  opacity:.65;
+}
+.partner-card::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  z-index:2;
+  background:linear-gradient(200deg, rgba(10,8,28,0) 40%, rgba(8,6,24,0.88) 100%);
+}
+.partner-card__meta{
+  position:absolute;
+  inset:auto clamp(12px,2vw,18px) clamp(12px,2vw,18px) clamp(12px,2vw,18px);
+  z-index:3;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  align-items:flex-start;
+}
+.partner-card__meta::before{
+  content:"";
+  display:block;
+  width:34px;
+  height:3px;
+  border-radius:999px;
+  background:linear-gradient(90deg, var(--accent), var(--accent-2));
+  box-shadow:0 0 12px rgba(123,92,255,0.45);
+}
+.partner-card__nick{
+  font-weight:800;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  font-size:clamp(12px,1.05vw,14px);
+  color:#fff;
+  text-shadow:0 6px 18px rgba(0,0,0,0.8);
+}
+.partner-card__tag{
+  font-weight:600;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  font-size:clamp(10px,.92vw,12px);
+  color:rgba(214,208,255,0.75);
+}
+
+@media(max-width:980px){
+  .partner-card{width:clamp(150px,28vw,220px);}
+}
+@media(max-width:720px){
+  .partners-marquee{padding:32px 0;}
+  .partners-marquee::before,
+  .partners-marquee::after{width:18%;}
+  .partner-card{width:clamp(150px,44vw,220px);}
+}
+@media(max-width:560px){
+  .partner-card__meta{inset:auto 12px 12px 12px;}
+  .partner-card__nick{letter-spacing:.06em;}
+  .partner-card__tag{letter-spacing:.12em;}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .partners-track{animation:none !important;transform:none !important;}
+}
+
 .reveal{opacity:0;transform:translateY(24px);transition:all .8s cubic-bezier(.2,.65,.15,1)}
 .reveal.visible{opacity:1;transform:none}
 

--- a/index.html
+++ b/index.html
@@ -298,32 +298,271 @@
     <div class="container">
       <h2 class="section-title" style="text-align:center">Наши партнеры</h2>
     </div>
-    <!-- Полноширинная бегущая строка под стиль сайта -->
-    <div class="ticker-bar" style="position:relative;width:100vw;margin-left:calc(50% - 50vw);overflow:hidden;border-top:1px solid rgba(123,92,255,.35);border-bottom:1px solid rgba(123,92,255,.35);background:linear-gradient(180deg,rgba(123,92,255,0.08),rgba(123,92,255,0.05));box-shadow:inset 0 0 24px rgba(123,92,255,.18)">
-      <div class="ticker-track" style="display:flex;gap:36px;white-space:nowrap;animation:rakodi-ticker 28s linear infinite;padding:14px 10px;will-change:transform">
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Тех‑поддержка</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Медиа</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Инфраструктура</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Аудит</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Платёжные партнёры</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Креаторы</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Маркет‑мейкинг</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Игровые студии</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Data‑провайдеры</span>
-        <!-- дублирование для бесшовной прокрутки -->
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Тех‑поддержка</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Медиа</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Инфраструктура</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Аудит</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Платёжные партнёры</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Креаторы</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Маркет‑мейкинг</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Игровые студии</span>
-        <span class="ticker-item" style="font-weight:800;letter-spacing:2px;text-transform:uppercase;color:#d6d0ff;text-shadow:0 0 6px rgba(123,92,255,.60),0 0 18px rgba(123,92,255,.30)">Data‑провайдеры</span>
+    <div class="partners-marquee" aria-label="Партнёры Rakodi">
+      <div class="partners-row">
+        <div class="partners-track partners-track--left">
+          <article class="partner-card">
+            <img src="assets/cat-traider.png" alt="Партнёр трейдерского коммьюнити" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@TradeFox</span>
+              <span class="partner-card__tag">Маркет-мейкер</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/city_girl.webp" alt="Партнёр медиа-проекта" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@NeonCity</span>
+              <span class="partner-card__tag">Медиа</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-wallet.png" alt="Партнёр кошелькового сервиса" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@WalletCraft</span>
+              <span class="partner-card__tag">Инфраструктура</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/hero_cowboy.webp" alt="Партнёр игровой студии" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@CowboyLabs</span>
+              <span class="partner-card__tag">Игры</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-millioner.png" alt="Инвест-партнёр Rakodi" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@WhaleSensei</span>
+              <span class="partner-card__tag">Капитал</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-search.png" alt="Партнёр аналитического сервиса" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@ScanVerse</span>
+              <span class="partner-card__tag">Аналитика</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-traider.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@TradeFox</span>
+              <span class="partner-card__tag">Маркет-мейкер</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/city_girl.webp" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@NeonCity</span>
+              <span class="partner-card__tag">Медиа</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-wallet.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@WalletCraft</span>
+              <span class="partner-card__tag">Инфраструктура</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/hero_cowboy.webp" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@CowboyLabs</span>
+              <span class="partner-card__tag">Игры</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-millioner.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@WhaleSensei</span>
+              <span class="partner-card__tag">Капитал</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-search.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@ScanVerse</span>
+              <span class="partner-card__tag">Аналитика</span>
+            </div>
+          </article>
+        </div>
       </div>
-      <style>
-        @keyframes rakodi-ticker { from { transform: translateX(0); } to { transform: translateX(-50%); } }
-      </style>
+      <div class="partners-row">
+        <div class="partners-track partners-track--right">
+          <article class="partner-card">
+            <img src="assets/20250922_1249_Cyberpunk%20Drone%20Mastery_simple_compose_01k5rgjwwbfr6bhhqy2yehf7v6.png" alt="Партнёр кибердронов" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@DroneMaster</span>
+              <span class="partner-card__tag">Техподдержка</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/20250922_1248_Cyberpunk%20Neon%20Warrior_simple_compose_01k5rghga2eg58bgf6pc0b3y8v.png" alt="Партнёр киберспорт" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@NeonBlade</span>
+              <span class="partner-card__tag">Киберспорт</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/20250922_0953_Hellenistic%20Cat%20Majesty_remix_01k5r6ey56ftjtzazr0xg1mmjp.png" alt="Творческий партнёр" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@CatMajesty</span>
+              <span class="partner-card__tag">Креаторы</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/20250922_1253_Neon_Visor_Monogram_remix_01k5r6fxgkeq7svghrvncrhmyv.png" alt="Партнёр по бренду" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@VisorClub</span>
+              <span class="partner-card__tag">Бренд</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/photo_2025-09-22_11-34-07.jpg" alt="Коммьюнити Rakodi" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LibraryDAO</span>
+              <span class="partner-card__tag">Комьюнити</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/duck.webp" alt="Мем-партнёр" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LuckyDuck</span>
+              <span class="partner-card__tag">Мемы</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/20250922_1249_Cyberpunk%20Drone%20Mastery_simple_compose_01k5rgjwwbfr6bhhqy2yehf7v6.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@DroneMaster</span>
+              <span class="partner-card__tag">Техподдержка</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/20250922_1248_Cyberpunk%20Neon%20Warrior_simple_compose_01k5rghga2eg58bgf6pc0b3y8v.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@NeonBlade</span>
+              <span class="partner-card__tag">Киберспорт</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/20250922_0953_Hellenistic%20Cat%20Majesty_remix_01k5r6ey56ftjtzazr0xg1mmjp.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@CatMajesty</span>
+              <span class="partner-card__tag">Креаторы</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/20250922_1253_Neon_Visor_Monogram_remix_01k5r6fxgkeq7svghrvncrhmyv.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@VisorClub</span>
+              <span class="partner-card__tag">Бренд</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/photo_2025-09-22_11-34-07.jpg" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LibraryDAO</span>
+              <span class="partner-card__tag">Комьюнити</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/duck.webp" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LuckyDuck</span>
+              <span class="partner-card__tag">Мемы</span>
+            </div>
+          </article>
+        </div>
+      </div>
+      <div class="partners-row">
+        <div class="partners-track partners-track--left partners-track--slow">
+          <article class="partner-card">
+            <img src="assets/image.png" alt="Партнёр визуального продакшена" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@FrameForge</span>
+              <span class="partner-card__tag">Продакшн</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-sm.png" alt="Партнёр NFT" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@PixelClaw</span>
+              <span class="partner-card__tag">NFT</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-wallet.png" alt="Партнёр DeFi сервиса" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@DefiPort</span>
+              <span class="partner-card__tag">DeFi</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/city_girl.webp" alt="Партнёр по инфлюэнсерам" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@VibeSisters</span>
+              <span class="partner-card__tag">Инфлюенс</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/cat-millioner.png" alt="Партнёр по ликвидности" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LiquidityZen</span>
+              <span class="partner-card__tag">Ликвидность</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <img src="assets/duck.webp" alt="Партнёр комьюнити мемов" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@QuackGang</span>
+              <span class="partner-card__tag">Комьюнити</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/image.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@FrameForge</span>
+              <span class="partner-card__tag">Продакшн</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-sm.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@PixelClaw</span>
+              <span class="partner-card__tag">NFT</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-wallet.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@DefiPort</span>
+              <span class="partner-card__tag">DeFi</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/city_girl.webp" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@VibeSisters</span>
+              <span class="partner-card__tag">Инфлюенс</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/cat-millioner.png" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@LiquidityZen</span>
+              <span class="partner-card__tag">Ликвидность</span>
+            </div>
+          </article>
+          <article class="partner-card" aria-hidden="true">
+            <img src="assets/duck.webp" alt="" loading="lazy">
+            <div class="partner-card__meta">
+              <span class="partner-card__nick">@QuackGang</span>
+              <span class="partner-card__tag">Комьюнити</span>
+            </div>
+          </article>
+        </div>
+      </div>
     </div>
     <div class="container">
       <div class="hero-cta" style="margin-top:14px"><a href="#" class="btn">Стать партнёром</a></div>


### PR DESCRIPTION
## Summary
- replace the single-line partner ticker with a multi-row marquee of partner cards that animate in opposite directions
- add marquee-specific styling to match the neon gradient visual language and display nicknames on every partner image

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d149a05614832a85a4fa79054bd46b