### PR TITLE
Redesign legend narrative block

### DIFF
--- a/about.html
+++ b/about.html
@@ -166,18 +166,78 @@
   </section>
 
   <!-- 3) Легенда — «Новая Мем-Александрия» -->
-    <section id="legend" class="reveal">
+  <section id="legend" class="legend-section reveal">
     <div class="container">
-      <h2 class="section-title">Легенда, которая работает</h2>
-      <p class="section-sub">Александрийская библиотека — символ утраченного знания. Мы берём этот образ и переосмысляем: мемы становятся «листами» новой библиотеки, которую уже не сжечь.</p>
-      <div class="grid cols-2">
-        <div class="card">
-          <p>Ирония — наш двигатель виральности. Мы говорим языком интернета, но строим как инженеры: каждый мем, ролик и строчка кода вписаны в систему.</p>
+      <div class="legend-shell">
+        <div class="legend-head">
+          <span class="legend-chip">Нарратив RAKODI</span>
+          <h2 class="section-title">Легенда, которая работает</h2>
+          <p class="section-sub">Александрийская библиотека — символ утраченного знания. Мы берём этот образ и переосмысляем: мемы становятся «листами» новой библиотеки, которую уже не сжечь.</p>
         </div>
-        <div class="feature-media">
-          <video autoplay muted playsinline loop poster="assets/20250922_0953_Hellenistic Cat Majesty_remix_01k5r6ey56ftjtzazr0xg1mmjp.png">
-            <source src="assets/hero_bg.mp4" type="video/mp4">
-          </video>
+
+        <div class="legend-layout">
+          <article class="legend-story">
+            <header class="legend-story__head">
+              <span class="legend-badge">Мем-Александрия</span>
+              <span class="legend-emblem">✶</span>
+            </header>
+            <p>Ирония — наш двигатель виральности. Мы говорим языком интернета, но строим как инженеры: каждый мем, ролик и строка кода вписаны в систему.</p>
+            <ul class="legend-points">
+              <li>
+                <span class="legend-point-title">Образ, который цепляет</span>
+                <p>Орден хранителей мемов собирает «листки» в архив — визуальный лор для тизеров, сайта и сообществ.</p>
+              </li>
+              <li>
+                <span class="legend-point-title">Сценарий вовлечения</span>
+                <p>Каждый артефакт подбрасывает искру: тизеры, обсуждения в Telegram, разборы на сайте и действия в Братстве.</p>
+              </li>
+              <li>
+                <span class="legend-point-title">Технологичный фундамент</span>
+                <p>Автоматизация, аналитика и код превращают легенду в механику роста, а не просто красивый миф.</p>
+              </li>
+            </ul>
+          </article>
+
+          <div class="legend-media">
+            <div class="legend-holo">
+              <div class="legend-grid"></div>
+              <video autoplay muted playsinline loop poster="assets/20250922_0953_Hellenistic Cat Majesty_remix_01k5r6ey56ftjtzazr0xg1mmjp.png">
+                <source src="assets/hero_bg.mp4" type="video/mp4">
+              </video>
+            </div>
+            <div class="legend-meta">
+              <div class="legend-meta-item">
+                <span class="meta-label">Тон</span>
+                <span class="meta-value">Ироничный орден</span>
+                <p>Шлемы, манускрипты и мемы соседствуют с аналитикой и цифрами, создавая ощущение движения ордена.</p>
+              </div>
+              <div class="legend-meta-item">
+                <span class="meta-label">Герои</span>
+                <span class="meta-value">Хранители огня</span>
+                <p>Кураторы мемов и разработчики выступают персонажами мира — они несут знания дальше, а не охраняют пепел.</p>
+              </div>
+              <div class="legend-meta-item">
+                <span class="meta-label">Действие</span>
+                <span class="meta-value">Ритуалы комьюнити</span>
+                <p>Квесты, голосования и новые артефакты дают сообществу повод возвращаться и строить библиотеку вместе.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="legend-facts">
+          <div class="legend-fact">
+            <strong>Архетип</strong>
+            <p>Мы не ностальгируем по прошлому, а расширяем его: библиотека стала живым организмом, чутким к трендам.</p>
+          </div>
+          <div class="legend-fact">
+            <strong>Сигналы</strong>
+            <p>Тизеры, мемы и код — сигнальные башни, которые ведут людей к ядру экосистемы.</p>
+          </div>
+          <div class="legend-fact">
+            <strong>Обещание</strong>
+            <p>Каждый новый участник приносит лист в архивах и усиливает ценность токена.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -413,6 +413,315 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .mission-node + .mission-node{margin-top:18px}
 }
 
+.legend-section{
+  position:relative;
+  padding:150px 0;
+  background:
+    radial-gradient(960px 540px at 12% 0%, rgba(123,92,255,0.12), transparent 72%),
+    radial-gradient(820px 520px at 88% 12%, rgba(255,46,106,0.08), transparent 70%),
+    linear-gradient(120deg,var(--bg-1),var(--bg-2));
+  border-bottom:var(--border);
+  overflow:hidden;
+}
+.legend-shell{
+  position:relative;
+  border-radius:36px;
+  padding:clamp(32px,4vw,56px);
+  border:1px solid rgba(134,114,255,0.32);
+  background:linear-gradient(160deg,rgba(21,16,40,0.92) 0%,rgba(18,12,32,0.74) 52%,rgba(26,20,44,0.88) 100%);
+  box-shadow:0 40px 90px rgba(5,4,20,0.65);
+  overflow:hidden;
+  isolation:isolate;
+}
+.legend-shell::before,
+.legend-shell::after{
+  content:"";
+  position:absolute;
+  pointer-events:none;
+}
+.legend-shell::before{
+  inset:-40% auto auto -24%;
+  width:520px;
+  height:520px;
+  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.45), transparent 65%);
+  opacity:.45;
+}
+.legend-shell::after{
+  right:-22%;
+  top:-28%;
+  width:420px;
+  height:420px;
+  background:radial-gradient(circle at 50% 50%, rgba(255,46,106,0.38), transparent 68%);
+  opacity:.32;
+  filter:blur(1px);
+}
+.legend-head{
+  position:relative;
+  z-index:2;
+  display:grid;
+  gap:12px;
+  max-width:720px;
+}
+.legend-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.18);
+  background:rgba(14,16,36,0.68);
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(241,239,255,0.82);
+}
+.legend-chip::before{
+  content:"◎";
+  color:var(--accent);
+  font-size:14px;
+}
+.legend-head .section-title{margin-bottom:0}
+.legend-head .section-sub{margin-bottom:0;color:rgba(226,224,255,0.76)}
+
+.legend-layout{
+  position:relative;
+  z-index:2;
+  margin-top:48px;
+  display:grid;
+  gap:32px;
+  grid-template-columns:minmax(0,1.05fr) minmax(0,0.95fr);
+  align-items:stretch;
+}
+
+.legend-story{
+  position:relative;
+  padding:clamp(28px,3.4vw,42px);
+  border-radius:28px;
+  background:linear-gradient(185deg,rgba(123,92,255,0.18),rgba(18,16,36,0.82));
+  border:1px solid rgba(255,255,255,0.14);
+  box-shadow:0 28px 62px rgba(4,2,20,0.55);
+}
+.legend-story::after{
+  content:"";
+  position:absolute;
+  inset:24px 22px auto;
+  height:1px;
+  background:linear-gradient(90deg,rgba(255,255,255,0.24),transparent 60%);
+  opacity:.6;
+}
+.legend-story__head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:28px;
+}
+.legend-badge{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 18px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.2);
+  background:rgba(255,255,255,0.08);
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(249,248,255,0.88);
+}
+.legend-badge::before{
+  content:"✦";
+  font-size:13px;
+  color:var(--accent-2);
+}
+.legend-emblem{
+  font-size:24px;
+  color:rgba(255,255,255,0.34);
+  text-shadow:0 0 18px rgba(123,92,255,0.45);
+}
+.legend-story > p{
+  margin:0 0 22px;
+  color:rgba(244,243,255,0.9);
+  line-height:1.65;
+  font-size:17px;
+}
+.legend-points{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:18px;
+}
+.legend-points li{
+  position:relative;
+  padding:18px 20px 18px 24px;
+  border-radius:18px;
+  background:rgba(12,14,30,0.72);
+  border:1px solid rgba(255,255,255,0.08);
+  box-shadow:inset 0 0 0 1px rgba(123,92,255,0.12);
+}
+.legend-points li::before{
+  content:"";
+  position:absolute;
+  left:10px;
+  top:16px;
+  bottom:16px;
+  width:3px;
+  border-radius:999px;
+  background:linear-gradient(180deg,var(--accent),var(--accent-2));
+  opacity:.85;
+}
+.legend-point-title{
+  display:block;
+  font-weight:700;
+  font-size:16px;
+  letter-spacing:.02em;
+  margin-bottom:6px;
+}
+.legend-points p{
+  margin:0;
+  color:rgba(219,217,245,0.82);
+  line-height:1.55;
+}
+
+.legend-media{
+  display:grid;
+  gap:24px;
+}
+.legend-holo{
+  position:relative;
+  border-radius:28px;
+  padding:18px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:linear-gradient(165deg,rgba(12,14,30,0.92),rgba(8,10,24,0.7));
+  box-shadow:0 26px 64px rgba(4,4,18,0.6);
+  overflow:hidden;
+}
+.legend-holo::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(420px 260px at 20% 20%, rgba(255,46,106,0.24), transparent 70%);
+  opacity:.4;
+  pointer-events:none;
+}
+.legend-grid{
+  position:absolute;
+  inset:12px;
+  border-radius:18px;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+  background-size:28px 28px;
+  opacity:.32;
+  pointer-events:none;
+}
+.legend-holo video{
+  position:relative;
+  width:100%;
+  border-radius:20px;
+  display:block;
+  border:1px solid rgba(255,255,255,0.16);
+  box-shadow:0 18px 40px rgba(0,0,0,0.45);
+  z-index:1;
+}
+
+.legend-meta{
+  display:grid;
+  gap:18px;
+  padding:22px;
+  border-radius:26px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(10,12,28,0.72);
+  box-shadow:0 24px 56px rgba(5,4,20,0.52);
+  grid-template-columns:repeat(auto-fit,minmax(190px,1fr));
+}
+.legend-meta-item{
+  position:relative;
+  padding-left:20px;
+}
+.legend-meta-item::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:10px;
+  bottom:10px;
+  width:3px;
+  border-radius:999px;
+  background:linear-gradient(180deg,var(--accent),var(--accent-2));
+  opacity:.75;
+}
+.meta-label{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:.28em;
+  color:rgba(214,212,244,0.58);
+}
+.meta-value{
+  font-size:18px;
+  font-weight:700;
+  letter-spacing:.02em;
+  color:rgba(244,243,255,0.92);
+  margin-top:6px;
+}
+.legend-meta-item p{
+  margin:6px 0 0;
+  color:rgba(214,212,244,0.8);
+  line-height:1.55;
+}
+
+.legend-facts{
+  position:relative;
+  z-index:2;
+  margin-top:52px;
+  display:grid;
+  gap:18px;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+}
+.legend-fact{
+  padding:20px 22px;
+  border-radius:20px;
+  border:1px solid rgba(255,255,255,0.1);
+  background:rgba(12,14,30,0.72);
+  box-shadow:0 18px 42px rgba(5,4,20,0.48);
+}
+.legend-fact strong{
+  display:block;
+  font-size:13px;
+  text-transform:uppercase;
+  letter-spacing:.28em;
+  color:rgba(229,226,250,0.68);
+  margin-bottom:12px;
+}
+.legend-fact p{
+  margin:0;
+  color:rgba(222,220,247,0.82);
+  line-height:1.6;
+}
+
+@media (max-width:1080px){
+  .legend-layout{grid-template-columns:1fr}
+  .legend-meta{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+}
+@media (max-width:820px){
+  .legend-section{padding:130px 0}
+  .legend-shell{padding:32px}
+  .legend-meta{grid-template-columns:1fr}
+  .legend-story::after{display:none}
+}
+@media (max-width:640px){
+  .legend-shell{padding:26px}
+  .legend-layout{margin-top:36px}
+  .legend-story{padding:24px}
+  .legend-points li{padding-left:22px}
+  .legend-facts{grid-template-columns:1fr;margin-top:40px}
+}
+@media (max-width:480px){
+  .legend-chip{letter-spacing:.2em}
+  .legend-meta{padding:18px}
+  .legend-holo{padding:14px}
+}
+
 .quest-section{
   overflow:hidden;
   background:


### PR DESCRIPTION
## Summary
- rebuild the legend section on the about page with a narrative shell, meta highlights, and supporting facts
- add dedicated styling for the legend block including holographic media frame, list items, and responsive tuning

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1523c6898832abc530ade7a578736