### PR TITLE
Redesign ecosystem section with orbital infographic

### DIFF
--- a/about.html
+++ b/about.html
@@ -187,27 +187,107 @@
   <section id="ecosystem" class="reveal">
     <div class="container">
       <h2 class="section-title">Как всё соединено</h2>
-      <div class="grid cols-2">
-        <div class="card"><h3>Сайт — нервный центр</h3><p class="muted">Здесь — смысл, структура, токеномика, квесты и живые метрики. Сюда приводит весь внешний трафик.</p></div>
-        <div class="card"><h3>YouTube — медиаядро</h3><p class="muted">Клиповые тизеры в игровом/киношном стиле. Эмоция → внимание → переход на сайт.</p></div>
-        <div class="card"><h3>Telegram — форум Братства</h3><p class="muted">Обсуждения, анонсы, голосования, мемы дня. Первая точка входа в «ритуалы» комьюнити.</p></div>
-        <div class="card"><h3>Соцсети — сетка сигналов</h3><p class="muted">X, Instagram, (по ситуации) Reddit для англоязычной ветки. Усиливаем охват и приводим людей к видео и на сайт.</p></div>
+      <p class="section-sub">Орбитальная схема показывает, как каждый канал ловит внимание и возвращает его в нервный центр экосистемы.</p>
+
+      <div class="ecosystem-diagram">
+        <svg class="ecosystem-links" viewBox="0 0 800 600" aria-hidden="true" focusable="false">
+          <defs>
+            <linearGradient id="ecosystem-line" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="rgba(255,46,106,0.85)"/>
+              <stop offset="50%" stop-color="rgba(123,92,255,0.65)"/>
+              <stop offset="100%" stop-color="rgba(76,217,253,0.6)"/>
+            </linearGradient>
+            <radialGradient id="ecosystem-core" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="rgba(255,46,106,0.8)"/>
+              <stop offset="60%" stop-color="rgba(123,92,255,0.25)"/>
+              <stop offset="100%" stop-color="rgba(12,16,32,0)"/>
+            </radialGradient>
+            <radialGradient id="ecosystem-orbit" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stop-color="rgba(255,255,255,0.22)"/>
+              <stop offset="70%" stop-color="rgba(255,255,255,0.02)"/>
+              <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+            </radialGradient>
+          </defs>
+          <circle cx="400" cy="300" r="188" fill="none" stroke="url(#ecosystem-line)" stroke-width="1.4" stroke-dasharray="10 18" opacity="0.55" class="ecosystem-orbit"/>
+          <circle cx="400" cy="300" r="262" fill="none" stroke="url(#ecosystem-line)" stroke-width="1.1" stroke-dasharray="12 26" opacity="0.35" class="ecosystem-orbit"/>
+          <circle cx="400" cy="300" r="118" fill="url(#ecosystem-orbit)" opacity="0.5"/>
+          <path d="M400 300 C 332 236 260 198 170 158" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
+          <path d="M400 300 C 336 352 280 398 188 426" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
+          <path d="M400 300 C 476 266 542 238 604 260" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
+          <circle cx="400" cy="300" r="74" fill="url(#ecosystem-core)" opacity="0.7"/>
+        </svg>
+
+        <article class="ecosystem-node ecosystem-node--site">
+          <span class="ecosystem-chip">Главный узел</span>
+          <h3>Сайт — нервный центр</h3>
+          <p>Живые метрики, токеномика, квесты и база знаний. Сюда стекается весь внешний трафик и превращается в участие.</p>
+          <ul class="ecosystem-meta">
+            <li>открытая аналитика и дашборды</li>
+            <li>документация и onboarding для Братства</li>
+          </ul>
+        </article>
+
+        <article class="ecosystem-node ecosystem-node--youtube">
+          <span class="ecosystem-icon" aria-hidden="true">
+            <svg viewBox="0 0 32 32" role="presentation" focusable="false">
+              <circle cx="16" cy="16" r="13.2" stroke="currentColor" stroke-width="2" opacity="0.6" fill="none"/>
+              <path d="M13 11.5L21 16L13 20.5V11.5Z" fill="currentColor"/>
+            </svg>
+          </span>
+          <h3>YouTube — медиаядро</h3>
+          <p>Клиповые тизеры, прямые эфиры и коллаборации. Эмоция зажигает внимание и ведёт к подробностям на сайте.</p>
+          <span class="ecosystem-note">Трейлеры • Бэкстейдж • Прямые стримы</span>
+        </article>
+
+        <article class="ecosystem-node ecosystem-node--telegram">
+          <span class="ecosystem-icon" aria-hidden="true">
+            <svg viewBox="0 0 32 32" role="presentation" focusable="false">
+              <path d="M5 16L26 6L20.5 26L15.4 20.7L20.8 11.5L12.1 18L5 16Z" fill="currentColor" opacity="0.92"/>
+            </svg>
+          </span>
+          <h3>Telegram — форум Братства</h3>
+          <p>Обсуждения, голосования, мемы дня и оперативные объявления. Первая точка входа в ритуалы комьюнити.</p>
+          <span class="ecosystem-note">Рейды • Квесты • Роли и награды</span>
+        </article>
+
+        <article class="ecosystem-node ecosystem-node--social">
+          <span class="ecosystem-icon" aria-hidden="true">
+            <svg viewBox="0 0 32 32" role="presentation" focusable="false">
+              <circle cx="10" cy="10" r="4" stroke="currentColor" stroke-width="2" fill="none"/>
+              <circle cx="22" cy="8" r="3" fill="currentColor" opacity="0.7"/>
+              <circle cx="24" cy="22" r="4" stroke="currentColor" stroke-width="2" fill="none"/>
+              <circle cx="9" cy="23" r="3" fill="currentColor" opacity="0.7"/>
+              <path d="M12.5 12.5L19 20" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+              <path d="M13 8L19 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+              <path d="M20 22L22 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+            </svg>
+          </span>
+          <h3>Соцсети — сетка сигналов</h3>
+          <p>X, Instagram и Reddit ловят новые аудитории. Усиливаем охват и возвращаем людей к видео и на сайт.</p>
+          <span class="ecosystem-note">Кросс-постинг • Мемы • Анонсы и спойлеры</span>
+        </article>
       </div>
 
-      <div style="width: min(1200px, 100%);" class="container">
-      <div class="card" style="margin:24px 0 0;text-align:center;width:100%">
-        <span class="badge">Сайт</span>
-        <span style="opacity:.6">↔</span>
-        <span class="badge">YouTube</span>
-        <span style="opacity:.6">↔</span>
-        <span class="badge">Telegram</span>
-        <span style="opacity:.6">↔</span>
-        <span class="badge">Соцсети</span>
+      <div class="ecosystem-flow">
+        <div class="flow-step">
+          <span class="flow-index">01</span>
+          <h4>Контент зажигает</h4>
+          <p>Видео и мемы создают эмоциональный вход. Основные CTA ведут на сайт и в Telegram.</p>
+        </div>
+        <div class="flow-step">
+          <span class="flow-index">02</span>
+          <h4>Сайт собирает</h4>
+          <p>Цифры, легенда и механики удерживают внимание, конвертируя его в регистрацию и покупку токена.</p>
+        </div>
+        <div class="flow-step">
+          <span class="flow-index">03</span>
+          <h4>Комьюнити усиливает</h4>
+          <p>Телеграм и соцсети возвращают инсайты в контент, замыкая петлю роста.</p>
+        </div>
       </div>
     </div>
-    </div>
-  
-    
+
+
   </section>
 
   <!-- 5) Контент-двигатель — «Как мемы двигают капитализацию» -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -155,6 +155,236 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:980px){.grid.cols-3{grid-template-columns:1fr 1fr}}
 @media (max-width:720px){.grid.cols-3,.grid.cols-2{grid-template-columns:1fr}}
 
+.ecosystem-diagram{
+  position:relative;
+  margin-top:36px;
+  padding:clamp(48px,7vw,96px);
+  min-height:520px;
+  border-radius:28px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:
+    radial-gradient(900px 720px at 12% 16%, rgba(123,92,255,0.14), transparent 70%),
+    radial-gradient(780px 640px at 86% 14%, rgba(76,217,253,0.12), transparent 72%),
+    linear-gradient(145deg, rgba(18,20,44,0.92), rgba(11,13,30,0.85));
+  box-shadow:0 40px 80px rgba(3,3,12,0.55);
+  overflow:hidden;
+}
+
+.ecosystem-diagram::before{
+  content:"";
+  position:absolute;
+  inset:-40% -30% auto;
+  height:360px;
+  background:radial-gradient(circle at 40% 0%, rgba(255,255,255,0.12), transparent 65%);
+  opacity:0.75;
+  pointer-events:none;
+  mix-blend-mode:screen;
+}
+
+.ecosystem-links{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  filter:drop-shadow(0 24px 60px rgba(35,18,66,0.55));
+  mix-blend-mode:screen;
+  pointer-events:none;
+}
+
+.ecosystem-orbit{animation:ecosystem-orbit 24s linear infinite}
+.ecosystem-line{
+  stroke-dasharray:12 16;
+  stroke-dashoffset:0;
+  animation:ecosystem-link 12s ease-in-out infinite;
+  opacity:0.75;
+}
+.ecosystem-links .ecosystem-line:nth-of-type(2){animation-duration:15s}
+.ecosystem-links .ecosystem-line:nth-of-type(3){animation-duration:18s}
+
+.ecosystem-node{
+  position:absolute;
+  width:min(270px,36vw);
+  padding:22px 24px;
+  border-radius:20px;
+  border:1px solid rgba(255,255,255,0.16);
+  background:linear-gradient(160deg, rgba(22,24,40,0.92), rgba(12,14,28,0.82));
+  box-shadow:0 18px 46px rgba(5,6,16,0.48);
+  backdrop-filter:blur(12px);
+  z-index:2;
+}
+
+.ecosystem-node h3{margin:8px 0 12px;font-size:22px;line-height:1.25}
+.ecosystem-node p{margin:0;color:#d7d7e6;line-height:1.55}
+
+.ecosystem-node--site{
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  width:min(320px,44vw);
+  text-align:center;
+  padding:28px 30px;
+  background:linear-gradient(180deg, rgba(32,34,66,0.95), rgba(18,12,40,0.88));
+  box-shadow:0 30px 70px rgba(12,8,30,0.65);
+  border:1px solid rgba(255,255,255,0.2);
+  animation:ecosystem-hub 14s ease-in-out infinite;
+}
+
+.ecosystem-node--youtube{top:10%;left:10%;animation:ecosystem-node-left 18s ease-in-out infinite}
+.ecosystem-node--telegram{bottom:8%;left:14%;animation:ecosystem-node-left 22s ease-in-out infinite}
+.ecosystem-node--social{top:18%;right:8%;animation:ecosystem-node-right 20s ease-in-out infinite}
+
+.ecosystem-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 14px;
+  border-radius:999px;
+  background:rgba(123,92,255,0.14);
+  border:1px solid rgba(123,92,255,0.35);
+  font-size:12px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  color:#f1edff;
+}
+
+.ecosystem-meta{
+  list-style:none;
+  padding:14px 0 0;
+  margin:0;
+  display:grid;
+  gap:6px;
+  font-size:14px;
+  color:#b9b5d8;
+}
+.ecosystem-meta li::before{
+  content:"•";
+  margin-right:8px;
+  color:var(--accent);
+}
+
+.ecosystem-icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:52px;
+  height:52px;
+  border-radius:16px;
+  background:linear-gradient(140deg, rgba(255,46,106,0.28), rgba(123,92,255,0.32));
+  color:#ff84b1;
+  box-shadow:0 16px 34px rgba(10,6,26,0.45);
+  margin-bottom:14px;
+}
+.ecosystem-icon svg{width:26px;height:26px;display:block}
+
+.ecosystem-note{
+  display:inline-flex;
+  margin-top:14px;
+  font-size:13px;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  color:rgba(255,255,255,0.65);
+  padding:6px 10px;
+  border-radius:999px;
+  background:rgba(17,18,34,0.76);
+  border:1px solid rgba(255,255,255,0.12);
+}
+
+.ecosystem-flow{
+  margin-top:46px;
+  display:flex;
+  gap:18px;
+  align-items:stretch;
+  justify-content:space-between;
+  background:linear-gradient(135deg, rgba(18,16,36,0.92), rgba(13,12,28,0.88));
+  border-radius:24px;
+  padding:26px clamp(18px,4vw,36px);
+  border:1px solid rgba(255,255,255,0.08);
+  box-shadow:0 24px 60px rgba(4,5,16,0.45);
+}
+
+.flow-step{
+  flex:1;
+  position:relative;
+  padding:0 clamp(12px,2.8vw,22px);
+}
+.flow-step:not(:last-child)::after{
+  content:"";
+  position:absolute;
+  top:20px;
+  right:0;
+  bottom:20px;
+  width:1px;
+  background:linear-gradient(180deg, rgba(255,255,255,0), rgba(255,255,255,0.35), rgba(255,255,255,0));
+  opacity:0.5;
+}
+
+.flow-index{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:38px;
+  height:38px;
+  border-radius:12px;
+  background:linear-gradient(135deg, rgba(255,46,106,0.28), rgba(123,92,255,0.4));
+  color:#fff;
+  font-weight:700;
+  font-size:14px;
+  letter-spacing:.08em;
+  margin-bottom:12px;
+  box-shadow:0 14px 28px rgba(8,6,24,0.55);
+}
+
+.flow-step h4{margin:0 0 10px;font-size:18px;line-height:1.3}
+.flow-step p{margin:0;color:#c8c4df;line-height:1.5;font-size:15px}
+
+@keyframes ecosystem-orbit{to{stroke-dashoffset:-280}}
+@keyframes ecosystem-link{0%,100%{stroke-dashoffset:0}50%{stroke-dashoffset:-120}}
+@keyframes ecosystem-hub{0%,100%{transform:translate(-50%,-50%) scale(1)}50%{transform:translate(-50%,-50%) scale(1.03)}}
+@keyframes ecosystem-node-left{0%,100%{transform:translateY(0)}50%{transform:translateY(-12px)}}
+@keyframes ecosystem-node-right{0%,100%{transform:translateY(0)}50%{transform:translateY(14px)}}
+
+@media (prefers-reduced-motion:reduce){
+  .ecosystem-orbit,.ecosystem-line,.ecosystem-node--site,.ecosystem-node--youtube,
+  .ecosystem-node--telegram,.ecosystem-node--social{animation:none}
+}
+
+@media (max-width:1180px){
+  .ecosystem-node{width:min(260px,40vw)}
+  .ecosystem-node--youtube{left:6%}
+  .ecosystem-node--telegram{left:10%}
+  .ecosystem-node--social{right:6%}
+}
+
+@media (max-width:960px){
+  .ecosystem-diagram{padding:clamp(36px,6vw,72px);min-height:480px}
+  .ecosystem-node--youtube{top:12%}
+  .ecosystem-node--social{top:22%}
+}
+
+@media (max-width:820px){
+  .ecosystem-diagram{
+    display:grid;
+    gap:18px;
+    padding:clamp(28px,6vw,48px);
+    min-height:auto;
+  }
+  .ecosystem-links{display:none}
+  .ecosystem-node{
+    position:relative;
+    top:auto;left:auto;right:auto;bottom:auto;
+    width:100%;
+    transform:none !important;
+    animation:none;
+  }
+  .ecosystem-note{justify-content:flex-start}
+}
+
+@media (max-width:720px){
+  .ecosystem-flow{flex-direction:column;gap:18px}
+  .flow-step{padding:0}
+  .flow-step:not(:last-child)::after{display:none}
+}
+
 .card{
   background:linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.03));
   border:var(--border);border-radius:18px;padding:22px;box-shadow:var(--shadow);


### PR DESCRIPTION
## Summary
- replace the simple ecosystem card grid with an orbital infographic layout and animated SVG links
- add bespoke styling for the new nodes, chips, and flow timeline to match the site's neon aesthetic
- introduce a bottom flow panel that illustrates how content, site, and community reinforce each other

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1527ce640832a979735f352e4995f