### PR TITLE
Redesign growth engine section

### DIFF
--- a/about.html
+++ b/about.html
@@ -213,31 +213,101 @@
   <!-- 5) Контент-двигатель — «Как мемы двигают капитализацию» -->
   <section id="engine" class="reveal">
     <div class="container">
-      <h2 class="section-title">Простая связка роста</h2>
-      <div class="grid cols-3">
-        <div class="card"><h3>I. Тизер</h3><p class="muted">эмоция и крючок из видео</p></div>
-        <div class="card"><h3>II. Просмотры</h3><p class="muted">охват и обсуждение в соцсетях</p></div>
-        <div class="card"><h3>III. Сайт</h3><p class="muted">понимание идеи, конверсия в Братство и токен</p></div>
-        <div class="card"><h3>IV. Комьюнити</h3><p class="muted">квесты, мем‑библиотека, UGC</p></div>
-        <div class="card"><h3>V. Сигналы рынка</h3><p class="muted">рост узнаваемости, путь к DEX</p></div>
+      <div class="growth-headline">
+        <span class="growth-chip">внимание → действие</span>
+        <h2 class="section-title">Простая связка роста</h2>
+        <p class="section-sub">Пять шагов соединяют вирусные эмоции, понятный онбординг и доказательство ценности. Каждая стадия усиливает предыдущую и приводит зрителя в устойчивое ядро сообщества.</p>
       </div>
-      <p class="small">Мы ничего не обещаем про цену. Мы строим систему, где внимание превращается в действие, а действие — в устойчивое сообщество.</p>
-      <div style="width: min(1200px, 100%);" class="container">
-      <div class="card" style="padding:12px;margin-top:10px; margin-inline: 0px">
-        <div style="height:8px;border-radius:8px;background:var(--glass);border:var(--border);overflow:hidden">
-          <div style="height:100%;width:40%;background:linear-gradient(90deg,var(--accent),var(--accent-2));"></div>
+      <div class="growth-layout">
+        <div class="growth-diagram">
+          <div class="growth-orbit"></div>
+          <div class="growth-core">
+            <span class="core-top">Импульс</span>
+            <strong>Внимание × Лояльность</strong>
+            <span class="core-bottom">Комьюнити</span>
+          </div>
+          <div class="growth-node step-1">
+            <div class="growth-bubble">I</div>
+            <div class="growth-node-body">
+              <h3>Тизер</h3>
+              <p class="muted">эмоция и крючок из видео</p>
+            </div>
+          </div>
+          <div class="growth-node step-2">
+            <div class="growth-bubble">II</div>
+            <div class="growth-node-body">
+              <h3>Просмотры</h3>
+              <p class="muted">охват и обсуждение в соцсетях</p>
+            </div>
+          </div>
+          <div class="growth-node step-3">
+            <div class="growth-bubble">III</div>
+            <div class="growth-node-body">
+              <h3>Сайт</h3>
+              <p class="muted">понимание идеи, конверсия в Братство и токен</p>
+            </div>
+          </div>
+          <div class="growth-node step-4">
+            <div class="growth-bubble">IV</div>
+            <div class="growth-node-body">
+              <h3>Комьюнити</h3>
+              <p class="muted">квесты, мем‑библиотека, UGC</p>
+            </div>
+          </div>
+          <div class="growth-node step-5">
+            <div class="growth-bubble">V</div>
+            <div class="growth-node-body">
+              <h3>Сигналы рынка</h3>
+              <p class="muted">рост узнаваемости, путь к DEX</p>
+            </div>
+          </div>
         </div>
-        <div class="statbar" style="margin-top:8px;justify-content:space-between">
-          <span class="badge">I</span>
-          <span class="badge">II</span>
-          <span class="badge">III</span>
-          <span class="badge">IV</span>
-          <span class="badge">V</span>
+        <div class="growth-info">
+          <div class="growth-info-card card">
+            <h3>Как работает связка</h3>
+            <p class="muted">Связываем эмоцию, структуру и социальное доказательство. Поток проходит через медиа, платформу и живое сообщество, чтобы закрепить ценность.</p>
+            <ul class="growth-list">
+              <li>
+                <span class="growth-dot">I–II</span>
+                <div>
+                  <strong>Импульс медиа</strong>
+                  <p class="muted">Тизеры и просмотры поднимают эмоциональную волну и обрастают обсуждениями.</p>
+                </div>
+              </li>
+              <li>
+                <span class="growth-dot">III</span>
+                <div>
+                  <strong>Онбординг</strong>
+                  <p class="muted">Сайт объясняет идею, приводит в Братство и даёт понятный первый шаг.</p>
+                </div>
+              </li>
+              <li>
+                <span class="growth-dot">IV–V</span>
+                <div>
+                  <strong>Сообщество и доверие</strong>
+                  <p class="muted">Комьюнити удерживает внимание квестами, а сигналы рынка подтверждают рост.</p>
+                </div>
+              </li>
+            </ul>
+            <div class="growth-progress" style="--growth-progress:0.62">
+              <div class="growth-progress-track">
+                <div class="growth-progress-fill"></div>
+              </div>
+              <div class="growth-progress-labels">
+                <span>I</span>
+                <span>II</span>
+                <span>III</span>
+                <span>IV</span>
+                <span>V</span>
+              </div>
+              <p class="growth-progress-caption small">Сейчас раскачиваем первые этапы, чтобы масштабировать эффект и перевести его в долгосрочную ценность сообщества.</p>
+            </div>
+          </div>
         </div>
       </div>
+      <p class="growth-note small">Мы ничего не обещаем про цену. Мы строим систему, где внимание превращается в действие, а действие — в устойчивое сообщество.</p>
     </div>
-    </div>
-  
+
   </section>
 
   <!-- 6) Мем-библиотека — «Архив, который смеётся» -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -413,6 +413,294 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .mission-node + .mission-node{margin-top:18px}
 }
 
+/* Growth engine — инфографика связки роста */
+#engine{overflow:hidden}
+#engine::before{
+  content:"";
+  position:absolute;
+  inset:-45% -40% auto 50%;
+  width:520px;
+  height:520px;
+  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.22), transparent 70%);
+  opacity:.55;
+  transform:translateX(-50%);
+  pointer-events:none;
+  filter:blur(0.6px);
+}
+#engine .container{position:relative;z-index:1}
+
+.growth-headline{max-width:760px;margin:0 auto 60px;text-align:center;display:grid;gap:16px}
+.growth-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  margin-inline:auto;
+  padding:6px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.16);
+  background:rgba(255,255,255,0.05);
+  text-transform:uppercase;
+  letter-spacing:.24em;
+  font-size:12px;
+  color:#fff9;
+}
+.growth-chip::before{content:"◈";color:var(--accent);font-size:14px;opacity:.86}
+
+.growth-layout{display:grid;gap:48px;grid-template-columns:minmax(0,1.1fr) minmax(0,0.9fr);align-items:stretch}
+
+.growth-diagram{
+  position:relative;
+  border-radius:32px;
+  padding:72px 64px;
+  background:linear-gradient(180deg, rgba(18,20,36,0.9), rgba(11,11,22,0.68));
+  border:1px solid rgba(255,255,255,0.12);
+  box-shadow:0 26px 60px rgba(8,4,22,0.55);
+  min-height:520px;
+  overflow:hidden;
+  isolation:isolate;
+}
+.growth-diagram::before{
+  content:"";
+  position:absolute;
+  inset:10% 14%;
+  border-radius:50%;
+  background:radial-gradient(circle at 50% 50%, rgba(255,255,255,0.04), transparent 62%);
+  border:1px solid rgba(255,255,255,0.06);
+  opacity:.8;
+  pointer-events:none;
+}
+
+.growth-orbit{
+  position:absolute;
+  inset:18%;
+  border-radius:50%;
+  border:1px dashed rgba(255,255,255,0.12);
+  background:conic-gradient(from 90deg, rgba(255,46,106,0.28), rgba(123,92,255,0.04) 40%, rgba(255,46,106,0.28) 80%, rgba(123,92,255,0.08));
+  opacity:.55;
+  filter:blur(0.4px);
+  pointer-events:none;
+}
+
+.growth-core{
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  width:230px;
+  aspect-ratio:1/1;
+  border-radius:50%;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
+  text-align:center;
+  text-transform:uppercase;
+  letter-spacing:.22em;
+  font-size:12px;
+  color:#f4f2ff;
+  background:radial-gradient(circle at 34% 32%, rgba(255,46,106,0.32), rgba(15,16,30,0.88));
+  border:1px solid rgba(255,255,255,0.18);
+  box-shadow:0 30px 60px rgba(7,4,26,0.52);
+}
+.growth-core::before{
+  content:"";
+  position:absolute;
+  inset:-20%;
+  border-radius:50%;
+  background:linear-gradient(135deg, rgba(255,46,106,0.42), rgba(123,92,255,0.4));
+  opacity:.35;
+  filter:blur(22px);
+  z-index:-1;
+}
+.growth-core strong{font-size:18px;letter-spacing:.18em;line-height:1.4}
+.growth-core .core-top,.growth-core .core-bottom{font-size:11px;opacity:.75;letter-spacing:.28em}
+
+.growth-node{
+  position:absolute;
+  display:flex;
+  align-items:flex-start;
+  gap:14px;
+  width:216px;
+  padding:16px 18px;
+  border-radius:22px;
+  background:rgba(10,12,26,0.78);
+  border:1px solid rgba(255,255,255,0.14);
+  box-shadow:0 22px 48px rgba(6,3,18,0.5);
+  backdrop-filter:blur(12px);
+  z-index:2;
+}
+.growth-node h3{margin:0;font-size:18px;letter-spacing:.02em}
+.growth-node p{margin:6px 0 0;font-size:14px;line-height:1.5}
+.growth-node-body{display:grid;gap:6px}
+
+.growth-bubble{
+  width:46px;
+  height:46px;
+  border-radius:14px;
+  display:grid;
+  place-items:center;
+  font-weight:700;
+  letter-spacing:.08em;
+  color:#fff;
+  background:linear-gradient(140deg,var(--accent),var(--accent-2));
+  box-shadow:0 12px 24px rgba(255,46,106,0.35);
+  flex-shrink:0;
+}
+
+.growth-node.step-1{top:18px;left:50%;transform:translate(-50%,0);flex-direction:column;align-items:center;text-align:center;width:220px}
+.growth-node.step-1 .growth-bubble{margin-bottom:10px}
+.growth-node.step-1::after{
+  content:"";
+  position:absolute;
+  top:calc(100% + 4px);
+  left:50%;
+  width:1px;
+  height:76px;
+  background:linear-gradient(180deg, rgba(255,255,255,0.5), rgba(123,92,255,0));
+  transform:translateX(-50%);
+  opacity:.7;
+}
+
+.growth-node.step-2{top:122px;right:22px}
+.growth-node.step-2::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  right:calc(100% - 24px);
+  width:128px;
+  height:1px;
+  background:linear-gradient(270deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
+  transform-origin:right center;
+  transform:rotate(18deg);
+  opacity:.7;
+}
+
+.growth-node.step-3{bottom:118px;right:26px}
+.growth-node.step-3::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  right:calc(100% - 22px);
+  width:134px;
+  height:1px;
+  background:linear-gradient(270deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
+  transform-origin:right center;
+  transform:rotate(-16deg);
+  opacity:.7;
+}
+
+.growth-node.step-4{bottom:40px;left:28px}
+.growth-node.step-4::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  left:calc(100% - 24px);
+  width:136px;
+  height:1px;
+  background:linear-gradient(90deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
+  transform-origin:left center;
+  transform:rotate(-12deg);
+  opacity:.7;
+}
+
+.growth-node.step-5{top:152px;left:24px}
+.growth-node.step-5::after{
+  content:"";
+  position:absolute;
+  top:50%;
+  left:calc(100% - 24px);
+  width:132px;
+  height:1px;
+  background:linear-gradient(90deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
+  transform-origin:left center;
+  transform:rotate(20deg);
+  opacity:.7;
+}
+
+.growth-info{display:flex;flex-direction:column;gap:24px}
+.growth-info-card{display:grid;gap:24px}
+.growth-info-card h3{margin:0;font-size:26px}
+
+.growth-list{list-style:none;margin:0;padding:0;display:grid;gap:18px}
+.growth-list li{display:flex;gap:14px;align-items:flex-start}
+.growth-list li div{display:grid;gap:6px}
+.growth-list li p{margin:0;line-height:1.55}
+.growth-list li strong{font-size:18px;letter-spacing:.02em}
+
+.growth-dot{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:64px;
+  padding:8px 14px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,0.22);
+  background:linear-gradient(140deg, rgba(255,255,255,0.05), rgba(123,92,255,0.12));
+  box-shadow:inset 0 0 18px rgba(123,92,255,0.25);
+  font-weight:700;
+  letter-spacing:.1em;
+  font-size:13px;
+  color:#f2f0ff;
+}
+
+.growth-progress{display:grid;gap:12px;padding:4px;border-radius:20px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.08)}
+.growth-progress-track{position:relative;height:12px;border-radius:999px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);overflow:hidden}
+.growth-progress-fill{position:absolute;inset:0;width:calc(var(--growth-progress,0.5) * 100%);background:linear-gradient(90deg,var(--accent),var(--accent-2));box-shadow:0 0 16px rgba(123,92,255,0.45)}
+.growth-progress-labels{display:flex;justify-content:space-between;gap:8px;font-size:12px;text-transform:uppercase;letter-spacing:.18em;color:#fff9}
+.growth-progress-labels span{display:grid;place-items:center;min-width:38px;height:28px;border-radius:999px;border:1px solid rgba(255,255,255,0.16);background:rgba(255,255,255,0.04);font-weight:600}
+.growth-progress-caption{margin:0;color:rgba(236,231,255,0.65)}
+
+.growth-note{margin:40px auto 0;text-align:center;max-width:720px;color:rgba(236,231,255,0.7)}
+
+@media (max-width:1080px){
+  .growth-layout{grid-template-columns:1fr}
+  .growth-diagram{margin-inline:auto}
+}
+
+@media (max-width:860px){
+  .growth-diagram{padding:56px 44px;min-height:480px}
+  .growth-node{width:200px}
+  .growth-node.step-2{top:110px;right:16px}
+  .growth-node.step-3{bottom:110px;right:18px}
+  .growth-node.step-4{bottom:38px;left:18px}
+  .growth-node.step-5{top:142px;left:16px}
+}
+
+@media (max-width:760px){
+  .growth-layout{gap:36px}
+  .growth-diagram{padding:36px 26px;min-height:0;display:grid;gap:18px}
+  .growth-diagram::before,.growth-orbit{display:none}
+  .growth-node{
+    position:relative;
+    width:100%;
+    left:auto;
+    right:auto;
+    top:auto;
+    bottom:auto;
+    transform:none !important;
+    background:rgba(16,17,36,0.88);
+  }
+  .growth-node::after{display:none}
+  .growth-node.step-1{flex-direction:row;align-items:flex-start;text-align:left}
+  .growth-node.step-1 .growth-bubble{margin-bottom:0}
+  .growth-core{
+    position:relative;
+    transform:none;
+    margin:0 auto 12px;
+    width:min(240px,70vw);
+  }
+  .growth-info-card{padding:6px 0}
+  .growth-dot{min-width:56px}
+}
+
+@media (max-width:520px){
+  .growth-diagram{padding:28px 20px}
+  .growth-core{width:min(220px,68vw)}
+  .growth-dot{min-width:48px;font-size:12px;letter-spacing:.08em}
+  .growth-progress-labels span{min-width:34px;height:26px;font-size:11px}
+}
+
 .quest-section{
   overflow:hidden;
   background:


### PR DESCRIPTION
## Summary
- Replace the growth engine cards with a bespoke infographic layout that visualises the five-stage funnel and adds supporting copy.
- Add new styling for the growth section, including radial diagram visuals, progress meter, and responsive behaviour.

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d152d18978832aba65e0768288c8e9