### PR TITLE
Fix prologue and legend styles outside mobile media query

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -929,6 +929,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .growth-core{width:min(220px,68vw)}
   .growth-dot{min-width:48px;font-size:12px;letter-spacing:.08em}
   .growth-progress-labels span{min-width:34px;height:26px;font-size:11px}
+}
 .legend-section{
   position:relative;
   padding:150px 0;


### PR DESCRIPTION
## Summary
- close the small-screen media query before the about-page sections to restore their desktop styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d15a3c4f38832a9a34b6d1b6d63f32