### PR TITLE
Fix Telegram ecosystem card layering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -242,9 +242,11 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   animation:ecosystem-node-left 18s ease-in-out infinite;
 }
 .ecosystem-node--telegram{
-  bottom:10%;
-  left:clamp(18px, 4.2vw, 72px);
-  animation:ecosystem-node-left 22s ease-in-out infinite;
+  top:calc(50% + 168px);
+  left:50%;
+  transform:translate(-50%,-50%);
+  animation:ecosystem-node-center 22s ease-in-out infinite;
+  z-index:3;
 }
 .ecosystem-node--social{
   top:20%;
@@ -255,7 +257,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 }
 
 .ecosystem-node--youtube{top:10%;left:10%;animation:ecosystem-node-left 18s ease-in-out infinite}
-.ecosystem-node--telegram{bottom:8%;left:14%;animation:ecosystem-node-left 22s ease-in-out infinite}
+.ecosystem-node--telegram{top:calc(50% + 168px);left:50%;transform:translate(-50%,-50%);animation:ecosystem-node-center 22s ease-in-out infinite;z-index:3}
 .ecosystem-node--social{top:18%;right:8%;animation:ecosystem-node-right 20s ease-in-out infinite}
 
 .ecosystem-chip{
@@ -367,6 +369,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @keyframes ecosystem-hub{0%,100%{transform:translate(-50%,-50%) scale(1)}50%{transform:translate(-50%,-50%) scale(1.03)}}
 @keyframes ecosystem-node-left{0%,100%{transform:translateY(0)}50%{transform:translateY(-12px)}}
 @keyframes ecosystem-node-right{0%,100%{transform:translateY(0)}50%{transform:translateY(14px)}}
+@keyframes ecosystem-node-center{0%,100%{transform:translate(-50%,-50%)}50%{transform:translate(-50%,-58%)}}
 
 @media (prefers-reduced-motion:reduce){
   .ecosystem-orbit,.ecosystem-line,.ecosystem-node--site,.ecosystem-node--youtube,
@@ -376,18 +379,15 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:1180px){
   .ecosystem-node{width:min(248px, 44vw)}
   .ecosystem-node--youtube{left:5%}
-  .ecosystem-node--telegram{left:9%}
-
-  .ecosystem-node{width:min(260px,40vw)}
-  .ecosystem-node--youtube{left:6%}
-  .ecosystem-node--telegram{left:10%}
   .ecosystem-node--social{right:6%}
+  .ecosystem-node--telegram{top:calc(50% + 150px)}
 }
 
 @media (max-width:960px){
   .ecosystem-diagram{padding:clamp(36px,6vw,72px);min-height:480px}
   .ecosystem-node--youtube{top:12%}
   .ecosystem-node--social{top:22%}
+  .ecosystem-node--telegram{top:calc(50% + 132px)}
 }
 
 @media (max-width:820px){


### PR DESCRIPTION
## Summary
- reposition the Telegram ecosystem node so it sits below the site hub without overlapping other cards
- introduce a center-aligned animation and responsive offsets to keep the forum card balanced across breakpoints

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d15eeb9028832ab132bf04f2680907