### PR TITLE
Restyle fraternity section

### DIFF
--- a/about.html
+++ b/about.html
@@ -482,24 +482,84 @@
   <!-- 7) Братство — «Роли, ритуалы, доступ» -->
   <section id="fraternity" class="reveal">
     <div class="container">
-      <h2 class="section-title">Братство Ракоди</h2>
-      <p class="section-sub">Мы организуемся в роли и «палаты». Доступ к частям экосистемы даёт участие и (где уместно) холд токена.</p>
-      <div class="grid cols-2">
-        <div class="card"><h3>Новобранец</h3><p class="muted">вход, базовые квесты, первый бэйдж.</p></div>
-        <div class="card"><h3>Смотритель</h3><p class="muted">куратор мемов и гайдов.</p></div>
-        <div class="card"><h3>Архивариус</h3><p class="muted">работает с «свитками» знаний, помогает формировать канон.</p></div>
-        <div class="card"><h3>Консул</h3><p class="muted">инициирует предложения, ведёт дискуссии и голосования.</p></div>
+      <div class="fraternity-layout">
+        <div class="fraternity-overview">
+          <div class="fraternity-heading">
+            <h2 class="section-title">Братство Ракоди</h2>
+            <p class="section-sub">Мы организуемся в роли и «палаты». Доступ к частям экосистемы даёт участие и (где уместно) холд токена.</p>
+          </div>
+          <div class="fraternity-grid">
+            <article class="fraternity-card">
+              <span class="fraternity-pill">Базовый вход</span>
+              <h3>Новобранец</h3>
+              <p class="muted">вход, базовые квесты, первый бэйдж.</p>
+            </article>
+            <article class="fraternity-card">
+              <span class="fraternity-pill">Кураторство</span>
+              <h3>Смотритель</h3>
+              <p class="muted">куратор мемов и гайдов.</p>
+            </article>
+            <article class="fraternity-card">
+              <span class="fraternity-pill">Свитки</span>
+              <h3>Архивариус</h3>
+              <p class="muted">работает с «свитками» знаний, помогает формировать канон.</p>
+            </article>
+            <article class="fraternity-card">
+              <span class="fraternity-pill">Совет</span>
+              <h3>Консул</h3>
+              <p class="muted">инициирует предложения, ведёт дискуссии и голосования.</p>
+            </article>
+          </div>
+          <div class="fraternity-meta">
+            <div class="fraternity-meta-item">
+              <span class="fraternity-meta-label">Приватный уровень</span>
+              <span class="fraternity-meta-value">Посвящённое братство</span>
+            </div>
+            <p class="small">Приватные комнаты и миссии с повышенными наградами доступны после вклада и участия в ритуалах.</p>
+          </div>
+        </div>
+        <aside class="fraternity-journey" aria-label="Этапы посвящения">
+          <div class="fraternity-journey-head">
+            <span class="fraternity-sigil" aria-hidden="true">Σ</span>
+            <div>
+              <h3>Путь посвящения</h3>
+              <p class="muted">Каждый шаг фиксирует вклад и открывает новый уровень доступа.</p>
+            </div>
+          </div>
+          <ol class="fraternity-steps">
+            <li class="fraternity-step">
+              <span class="fraternity-step-index">Шаг 1</span>
+              <div class="fraternity-step-body">
+                <h4>Вступление и первый бэйдж</h4>
+                <p>Присоединяйся к Telegram и активируй роль «Новобранец».</p>
+              </div>
+            </li>
+            <li class="fraternity-step">
+              <span class="fraternity-step-index">Шаг 2</span>
+              <div class="fraternity-step-body">
+                <h4>Первые квесты</h4>
+                <p>Выполняй задания и участвуй в мем‑библиотеке.</p>
+              </div>
+            </li>
+            <li class="fraternity-step">
+              <span class="fraternity-step-index">Шаг 3</span>
+              <div class="fraternity-step-body">
+                <h4>Курация и голос</h4>
+                <p>Переходи в роли Смотрителя/Архивариуса и подключайся к модерации.</p>
+              </div>
+            </li>
+            <li class="fraternity-step">
+              <span class="fraternity-step-index">Шаг 4</span>
+              <div class="fraternity-step-body">
+                <h4>Совет Консулов</h4>
+                <p>Ведёшь инициативы, формируешь повестку и участвуешь в стратегических голосованиях.</p>
+              </div>
+            </li>
+          </ol>
+        </aside>
       </div>
-      <p class="small">Посвящённое братство — приватные комнаты и миссии с повышенными наградами.</p>
     </div>
-  
-      <div class="container" style="margin-top:10px">
-        <div class="timeline">
-        <div class="milestone"><div class="when">Шаг 1</div><div>Вступление и первый бэйдж.</div></div>
-        <div class="milestone"><div class="when">Шаг 2</div><div>Первые квесты и участие в мем‑библиотеке.</div></div>
-        <div class="milestone"><div class="when">Шаг 3</div><div>Курация и голосования (Смотритель/Архивариус).</div></div>
-        <div class="milestone"><div class="when">Шаг 4</div><div>Инициативы и консулы.</div></div>
-      </div></section>
+  </section>
 
   <!-- 8) Награды и квесты — «Играй по‑серьёзному» -->
   <section id="quests" class="reveal quest-section">

--- a/css/styles.css
+++ b/css/styles.css
@@ -1994,6 +1994,251 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .legend .dot{width:12px;height:12px;border-radius:50%}
 .legend .name{color:var(--muted)}
 
+#fraternity{
+  background:
+    radial-gradient(880px 520px at 12% 12%, rgba(123,92,255,0.18), transparent 70%),
+    radial-gradient(720px 520px at 86% 0%, rgba(255,46,106,0.16), transparent 72%),
+    linear-gradient(180deg, rgba(12,12,26,0.92), rgba(8,8,20,0.92));
+  border-bottom:none;
+  isolation:isolate;
+}
+
+#fraternity::before{
+  content:"";
+  position:absolute;
+  inset:auto 10% -18% 10%;
+  height:280px;
+  background:radial-gradient(circle at 50% 0%, rgba(255,255,255,0.08), transparent 70%);
+  opacity:.6;
+  filter:blur(18px);
+  pointer-events:none;
+}
+
+.fraternity-layout{
+  position:relative;
+  display:grid;
+  grid-template-columns:minmax(0,1.1fr) minmax(0,0.9fr);
+  gap:32px;
+  align-items:stretch;
+  z-index:1;
+}
+
+.fraternity-heading{position:relative;padding-bottom:18px;margin-bottom:24px}
+.fraternity-heading::after{
+  content:"";
+  position:absolute;
+  left:0;
+  bottom:0;
+  width:86px;
+  height:3px;
+  border-radius:6px;
+  background:linear-gradient(90deg,var(--accent),var(--accent-2));
+  opacity:.9;
+}
+
+.fraternity-grid{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:18px;
+}
+
+.fraternity-card{
+  position:relative;
+  padding:22px 22px 24px;
+  border-radius:20px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:linear-gradient(155deg, rgba(20,20,38,0.92), rgba(13,11,30,0.88));
+  box-shadow:0 18px 44px rgba(8,6,26,0.45);
+  overflow:hidden;
+  transition:transform .25s ease, border-color .25s ease, box-shadow .25s ease;
+}
+
+.fraternity-card::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 80% -10%, rgba(255,46,106,0.24), transparent 70%);
+  opacity:.45;
+  pointer-events:none;
+}
+
+.fraternity-card:hover{
+  transform:translateY(-4px);
+  border-color:rgba(255,255,255,0.2);
+  box-shadow:0 24px 60px rgba(10,8,36,0.55);
+}
+
+.fraternity-card h3{margin:12px 0 10px;font-size:24px}
+
+.fraternity-pill{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 12px;
+  border-radius:999px;
+  font-size:13px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  background:rgba(255,255,255,0.06);
+  border:1px solid rgba(255,255,255,0.14);
+  color:#fff;
+}
+
+.fraternity-meta{margin-top:32px;display:flex;flex-direction:column;gap:10px}
+.fraternity-meta-item{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+.fraternity-meta-label{
+  padding:6px 12px;
+  border-radius:12px;
+  background:rgba(255,255,255,0.06);
+  border:1px solid rgba(255,255,255,0.14);
+  font-size:13px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:#fff;
+}
+.fraternity-meta-value{font-weight:700;font-size:18px}
+
+.fraternity-journey{
+  position:relative;
+  border-radius:26px;
+  padding:32px 28px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:linear-gradient(165deg, rgba(16,16,38,0.94), rgba(26,20,60,0.92));
+  box-shadow:0 32px 80px rgba(6,4,24,0.65);
+  overflow:hidden;
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+
+.fraternity-journey::before{
+  content:"";
+  position:absolute;
+  inset:18% -30% auto;
+  height:240px;
+  background:radial-gradient(circle at 30% 0%, rgba(255,46,106,0.3), transparent 65%);
+  opacity:.6;
+  pointer-events:none;
+}
+
+.fraternity-journey::after{
+  content:"";
+  position:absolute;
+  inset:auto -20% -30% -20%;
+  height:220px;
+  background:radial-gradient(circle at 50% 100%, rgba(123,92,255,0.32), transparent 70%);
+  opacity:.6;
+  pointer-events:none;
+  filter:blur(12px);
+}
+
+.fraternity-journey-head{
+  position:relative;
+  display:flex;
+  align-items:center;
+  gap:16px;
+  z-index:1;
+}
+
+.fraternity-sigil{
+  display:grid;
+  place-items:center;
+  width:54px;
+  height:54px;
+  border-radius:16px;
+  background:linear-gradient(135deg, rgba(255,46,106,0.85), rgba(123,92,255,0.85));
+  font-size:28px;
+  font-weight:700;
+  box-shadow:0 16px 38px rgba(15,8,38,0.55);
+}
+
+.fraternity-steps{
+  position:relative;
+  list-style:none;
+  margin:0;
+  padding:12px 0 12px 0;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+  z-index:1;
+}
+
+.fraternity-steps::before{
+  content:"";
+  position:absolute;
+  left:28px;
+  top:0;
+  bottom:0;
+  width:2px;
+  background:linear-gradient(180deg, rgba(255,46,106,0.85), rgba(123,92,255,0.1));
+  opacity:.7;
+}
+
+.fraternity-step{
+  position:relative;
+  display:flex;
+  gap:16px;
+  align-items:flex-start;
+  padding:16px 18px 16px 56px;
+  border-radius:20px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(10,10,22,0.55);
+  backdrop-filter:blur(6px);
+  transition:transform .25s ease, border-color .25s ease;
+}
+
+.fraternity-step::before{
+  content:"";
+  position:absolute;
+  left:22px;
+  top:24px;
+  width:14px;
+  height:14px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 6px rgba(123,92,255,0.22);
+}
+
+.fraternity-step:hover{transform:translateX(4px);border-color:rgba(255,255,255,0.18)}
+
+.fraternity-step-index{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:6px 14px;
+  border-radius:999px;
+  font-size:13px;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  font-weight:700;
+  background:rgba(255,255,255,0.08);
+  border:1px solid rgba(255,255,255,0.16);
+  color:#fff;
+  min-width:92px;
+}
+
+.fraternity-step-body h4{margin:0 0 6px;font-size:18px}
+.fraternity-step-body p{margin:0;color:#d2d2e6}
+
+@media (max-width:1080px){
+  .fraternity-layout{grid-template-columns:1fr;gap:40px}
+  .fraternity-journey{max-width:620px;margin-inline:auto}
+}
+
+@media (max-width:720px){
+  .fraternity-grid{grid-template-columns:1fr}
+  .fraternity-card h3{font-size:22px}
+  .fraternity-step{padding-left:52px}
+  .fraternity-step-index{min-width:82px;font-size:12px}
+}
+
+@media (max-width:520px){
+  .fraternity-journey{padding:26px 22px}
+  .fraternity-steps::before{left:24px}
+  .fraternity-step{padding:16px 16px 16px 46px}
+  .fraternity-step::before{left:18px}
+}
+
 .timeline{position:relative;padding-left:20px}
 .timeline::before{content:"";position:absolute;left:8px;top:6px;bottom:6px;width:2px;background:linear-gradient(var(--accent),transparent)}
 .milestone{position:relative;margin:14px 0;padding:12px 12px 12px 24px;background:var(--glass);border:var(--border);border-radius:12px}


### PR DESCRIPTION
## Summary
- redesign the "Братство Ракоди" block on about.html with a bespoke two-column layout and enriched step copy
- add dedicated styling for the new fraternity cards, meta details, and progression timeline to match the desired aesthetic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d16377eae8832aaed58d0d49dacc89