### PR TITLE
Restyle token role block on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -612,30 +612,53 @@
   </section>
 
   <!-- 9) Токен $RAKODI — «Топливо мем‑машины» -->
-  <section id="token" class="reveal">
+  <section id="token" class="reveal token-role">
     <div class="container">
-      <h2 class="section-title">Какую роль играет токен</h2>
-      <p class="section-sub">$RAKODI — сигнальный и мотивационный слой экосистемы. Он поддерживает квесты, роли, внутриигровые ритуалы и некоторые элементы доступа.</p>
-      <p>Сейчас токен торгуется на платформе <b>памфан</b>; при достижении целевого порога метрик мы переходим на DEX.</p>
-      <div class="grid cols-2" style="margin-top:6px">
-        <div class="card"><h3>Принципы</h3>
-          <ul>
-            <li>Простота механик.</li>
-            <li>Прозрачные параметры и адрес контракта.</li>
-            <li>Решения о развитии — с участием комьюнити.</li>
-          </ul>
+      <div class="token-role__wrap">
+        <div class="token-role__header">
+          <span class="token-role__label">Топливо мем‑машины</span>
+          <h2 class="section-title">Какую роль играет токен</h2>
+          <p class="section-sub">$RAKODI — сигнальный и мотивационный слой экосистемы. Он поддерживает квесты, роли, внутриигровые ритуалы и некоторые элементы доступа.</p>
+          <p class="token-role__text">Сейчас токен торгуется на платформе <b>памфан</b>; при достижении целевого порога метрик мы переходим на DEX.</p>
         </div>
-        <div class="card"><h3>Важно</h3><p class="muted">Это не инвестсовет. Крипто — риск. Делай собственное исследование (DYOR).</p></div>
+        <div class="token-role__grid">
+          <article class="token-role__panel token-role__panel--list">
+            <h3>Принципы</h3>
+            <ul class="token-role__list">
+              <li>Простота механик.</li>
+              <li>Прозрачные параметры и адрес контракта.</li>
+              <li>Решения о развитии — с участием комьюнити.</li>
+            </ul>
+          </article>
+          <article class="token-role__panel token-role__panel--alert">
+            <h3>Важно</h3>
+            <p class="token-role__muted">Это не инвестсовет. Крипто — риск. Делай собственное исследование (DYOR).</p>
+            <span class="token-role__note">Безопасность превыше всего</span>
+          </article>
+        </div>
+        <div class="token-role__meta">
+          <div class="token-role__status">
+            <span class="token-role__status-dot"></span>
+            <span>Торгуется: <strong>памфан</strong></span>
+          </div>
+          <div class="token-role__stats">
+            <div class="token-role__stat">
+              <span class="token-role__stat-label">Цена</span>
+              <span class="token-role__stat-value">[—]</span>
+            </div>
+            <div class="token-role__stat">
+              <span class="token-role__stat-label">MC</span>
+              <span class="token-role__stat-value">[—]</span>
+            </div>
+            <div class="token-role__stat">
+              <span class="token-role__stat-label">Ликвидность</span>
+              <span class="token-role__stat-value">[—]</span>
+            </div>
+          </div>
+        </div>
       </div>
-              <div class="badge" style="display:inline-block;margin-top:24px; width: min(1200px, 100%); margin-inline: 0">Торгуется: памфан</div>
-
     </div>
-  
-      <div class="statbar" style="margin-top:8px">
-        <div class="stat">Цена: <b>[—]</b></div>
-        <div class="stat">MC: <b>[—]</b></div>
-        <div class="stat">Ликвидность: <b>[—]</b></div>
-      </div></section>
+  </section>
 
   <!-- 10) Порог и переход на DEX — «Дорога с чекпоинтами» -->
   <section id="dex" class="reveal">

--- a/css/styles.css
+++ b/css/styles.css
@@ -149,6 +149,204 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .stat{padding:10px 18px;border-radius:14px;background:var(--glass);border:var(--border);font-weight:700}
 .stat small{display:block;color:var(--muted);font-weight:500}
 
+/* Token role block */
+.token-role .container{position:relative;z-index:1}
+.token-role__wrap{
+  position:relative;
+  padding:clamp(36px,6vw,64px);
+  border-radius:32px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:
+    radial-gradient(880px 420px at 12% -20%, rgba(255,46,106,0.26), transparent 68%),
+    radial-gradient(640px 540px at 88% -10%, rgba(123,92,255,0.24), transparent 72%),
+    linear-gradient(150deg, rgba(22,20,44,0.94), rgba(12,10,28,0.86));
+  box-shadow:0 40px 90px rgba(7,4,26,0.52);
+  overflow:hidden;
+}
+.token-role__wrap::after{
+  content:"";
+  position:absolute;
+  inset:auto -140px -140px auto;
+  width:340px;
+  height:340px;
+  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.35), transparent 70%);
+  opacity:.45;
+  filter:blur(2px);
+  pointer-events:none;
+}
+.token-role__header{
+  position:relative;
+  z-index:1;
+  display:grid;
+  gap:16px;
+  max-width:820px;
+}
+.token-role__label{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.18);
+  background:rgba(11,12,26,0.66);
+  letter-spacing:.24em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(255,255,255,0.72);
+  width:fit-content;
+}
+.token-role__label::before{content:"◒";color:var(--accent);font-size:14px;line-height:1}
+.token-role__header .section-title{margin:0}
+.token-role__header .section-sub{margin:0;color:#d8d6e8}
+.token-role__text{
+  margin:0;
+  color:#f1efff;
+  max-width:720px;
+  line-height:1.6;
+}
+.token-role__text b{color:#fff}
+.token-role__grid{
+  position:relative;
+  z-index:1;
+  margin-top:32px;
+  display:grid;
+  gap:24px;
+  grid-template-columns:minmax(0,1.05fr) minmax(0,0.95fr);
+}
+.token-role__panel{
+  position:relative;
+  padding:clamp(22px,3vw,32px);
+  border-radius:24px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:rgba(10,12,26,0.65);
+  backdrop-filter:blur(14px);
+  box-shadow:0 24px 48px rgba(6,4,20,0.42);
+}
+.token-role__panel h3{margin:0 0 16px;font-size:24px;letter-spacing:.02em}
+.token-role__list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:12px;
+}
+.token-role__list li{
+  position:relative;
+  padding-left:32px;
+  font-size:16px;
+  line-height:1.55;
+  color:#ece9ff;
+}
+.token-role__list li::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:8px;
+  width:14px;
+  height:14px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 4px rgba(255,255,255,0.08);
+}
+.token-role__panel--alert{
+  background:linear-gradient(165deg, rgba(255,46,106,0.22), rgba(13,10,28,0.85));
+  border-color:rgba(255,46,106,0.32);
+  box-shadow:0 26px 60px rgba(12,4,28,0.55);
+}
+.token-role__panel--alert h3{color:#ff8fb8}
+.token-role__muted{
+  margin:0;
+  color:rgba(255,236,247,0.82);
+  line-height:1.6;
+}
+.token-role__note{
+  margin-top:22px;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 14px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.24);
+  background:rgba(12,10,24,0.6);
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  font-size:11px;
+  color:#fff;
+}
+.token-role__note::before{content:"⚠";font-size:14px;line-height:1;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.4))}
+.token-role__meta{
+  position:relative;
+  z-index:1;
+  margin-top:36px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:18px;
+  align-items:center;
+}
+.token-role__status{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  padding:10px 20px;
+  border-radius:18px;
+  border:1px solid rgba(123,92,255,0.38);
+  background:rgba(123,92,255,0.18);
+  box-shadow:0 16px 36px rgba(6,4,24,0.45);
+  font-size:13px;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  color:#f7f4ff;
+}
+.token-role__status strong{font-size:14px;letter-spacing:.12em}
+.token-role__status-dot{
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 4px rgba(123,92,255,0.26);
+}
+.token-role__stats{
+  display:flex;
+  flex-wrap:wrap;
+  gap:14px;
+}
+.token-role__stat{
+  min-width:140px;
+  padding:14px 20px;
+  border-radius:18px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:rgba(10,12,28,0.58);
+  box-shadow:0 16px 36px rgba(5,4,18,0.45);
+  display:grid;
+  gap:6px;
+}
+.token-role__stat-label{
+  font-size:11px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:rgba(255,255,255,0.58);
+}
+.token-role__stat-value{
+  font-size:22px;
+  font-weight:700;
+  letter-spacing:.04em;
+  color:#fff;
+}
+@media (max-width:960px){
+  .token-role__grid{grid-template-columns:1fr}
+}
+@media (max-width:720px){
+  .token-role__wrap{padding:32px 24px}
+  .token-role__meta{flex-direction:column;align-items:stretch}
+  .token-role__status{justify-content:center;width:100%}
+  .token-role__stats{width:100%}
+  .token-role__stat{flex:1;min-width:calc(33.333% - 10px)}
+}
+@media (max-width:560px){
+  .token-role__stat{min-width:100%}
+  .token-role__stats{flex-direction:column}
+}
+
 .grid{display:grid;gap:24px}
 .grid.cols-3{grid-template-columns:repeat(3,1fr)}
 .grid.cols-2{grid-template-columns:repeat(2,1fr)}


### PR DESCRIPTION
## Summary
- redesign the token role section on the about page with a bespoke wrapper, grid, and CTA chips
- add scoped token-role styles for the new gradient panels, status ribbon, and stat badges

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d164b38300832a82a399748927151f