### PR TITLE
Redesign tokenomics hero block

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -149,6 +149,240 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .stat{padding:10px 18px;border-radius:14px;background:var(--glass);border:var(--border);font-weight:700}
 .stat small{display:block;color:var(--muted);font-weight:500}
 
+/* Tokenomics — cinematic hero */
+.hero-token{
+  position:relative;
+  padding:clamp(120px, 20vw, 220px) 0 120px;
+  overflow:hidden;
+}
+.hero-token .container{position:relative;z-index:1}
+.hero-token__shell{
+  position:relative;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) minmax(0,1.05fr);
+  gap:clamp(32px, 6vw, 72px);
+  padding:clamp(36px, 6vw, 72px);
+  border-radius:42px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(255,46,106,0.28), transparent 70%),
+    radial-gradient(120% 140% at 100% 0%, rgba(123,92,255,0.22), transparent 72%),
+    linear-gradient(150deg, rgba(16,14,36,0.94), rgba(10,8,26,0.82));
+  box-shadow:0 45px 120px rgba(6,4,24,0.7);
+  backdrop-filter:blur(18px);
+  overflow:hidden;
+  isolation:isolate;
+}
+.hero-token__shell::before,
+.hero-token__shell::after{
+  content:"";
+  position:absolute;
+  pointer-events:none;
+  filter:blur(18px);
+}
+.hero-token__shell::before{
+  inset:-34% 28% auto -38%;
+  height:340px;
+  background:radial-gradient(circle at 30% 50%, rgba(255,255,255,0.16), transparent 70%);
+  opacity:.65;
+}
+.hero-token__shell::after{
+  inset:auto -42% -64% 38%;
+  height:280px;
+  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.28), transparent 72%);
+  opacity:.5;
+}
+.hero-token__media{display:flex;align-items:center;justify-content:center}
+.hero-token__media-card{
+  position:relative;
+  width:min(420px, 100%);
+  aspect-ratio:3/4;
+  border-radius:36px;
+  border:1px solid rgba(255,255,255,0.12);
+  overflow:hidden;
+  background:linear-gradient(160deg, rgba(24,20,48,0.92), rgba(12,10,30,0.86));
+  box-shadow:0 28px 90px rgba(5,3,24,0.65);
+}
+.hero-token__media-card img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  filter:saturate(1.05) contrast(1.04);
+}
+.hero-token__media-card::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(200deg, rgba(255,255,255,0.12), transparent 48%, rgba(7,6,18,0.55));
+  mix-blend-mode:screen;
+  opacity:.55;
+}
+.hero-token__tag{
+  position:absolute;
+  left:22px;
+  bottom:22px;
+  padding:8px 18px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.24);
+  background:rgba(12,12,28,0.68);
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(255,255,255,0.78);
+}
+.hero-token__shine{
+  position:absolute;
+  border-radius:50%;
+  mix-blend-mode:screen;
+  opacity:.7;
+}
+.hero-token__shine--pink{
+  width:240px;
+  height:240px;
+  left:-52px;
+  bottom:-70px;
+  background:radial-gradient(circle, rgba(255,46,106,0.65), transparent 68%);
+}
+.hero-token__shine--violet{
+  width:200px;
+  height:200px;
+  right:-48px;
+  top:-60px;
+  background:radial-gradient(circle, rgba(123,92,255,0.6), transparent 70%);
+}
+.hero-token__content{
+  position:relative;
+  z-index:1;
+  display:flex;
+  flex-direction:column;
+  gap:clamp(18px, 2.6vw, 32px);
+  align-items:flex-start;
+}
+.hero-token__content .section-title{
+  margin:0;
+  font-size:clamp(38px, 5.6vw, 64px);
+}
+.hero-token__content .section-sub{
+  margin:0;
+  max-width:520px;
+  color:#d8d6e8;
+}
+.hero-token__eyebrow{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 18px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.18);
+  background:rgba(14,14,30,0.7);
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(255,255,255,0.78);
+}
+.hero-token__eyebrow::before{content:"◎";font-size:13px;color:var(--accent)}
+.hero-token__stats{
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0,1fr));
+  gap:18px;
+  width:100%;
+  max-width:520px;
+}
+.hero-token__stat{
+  padding:16px 20px;
+  border-radius:20px;
+  border:1px solid rgba(255,255,255,0.16);
+  background:linear-gradient(165deg, rgba(255,255,255,0.08), rgba(12,10,28,0.68));
+  box-shadow:0 22px 60px rgba(6,4,24,0.45);
+}
+.hero-token__stat-label{
+  display:block;
+  margin-bottom:6px;
+  font-size:12px;
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  color:rgba(255,255,255,0.72);
+}
+.hero-token__stat-value{
+  font-size:22px;
+  font-weight:700;
+  letter-spacing:.04em;
+}
+.hero-token__contract{
+  display:grid;
+  gap:14px;
+  width:100%;
+  max-width:560px;
+  padding:22px;
+  border-radius:24px;
+  border:1px solid rgba(255,255,255,0.16);
+  background:linear-gradient(170deg, rgba(16,14,36,0.92), rgba(8,6,22,0.72));
+  box-shadow:0 32px 80px rgba(5,3,24,0.55);
+}
+.hero-token__contract-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+.hero-token__contract-label{
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  font-size:12px;
+  color:rgba(255,255,255,0.72);
+}
+.hero-token__copy{
+  padding:6px 16px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.22);
+  background:rgba(255,255,255,0.08);
+  color:#fff;
+  font-size:11px;
+  font-weight:600;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  cursor:pointer;
+  transition:transform .2s ease, background .2s ease;
+}
+.hero-token__copy:hover{background:rgba(255,255,255,0.18);transform:translateY(-1px)}
+.hero-token__copy.copied{box-shadow:0 0 0 2px rgba(255,46,106,0.35)}
+.hero-token__contract-body span{
+  display:block;
+  font-size:18px;
+  letter-spacing:.08em;
+  font-weight:600;
+  font-family:"JetBrains Mono","Fira Code","SFMono-Regular","Menlo",monospace;
+  color:#fff;
+  word-break:break-all;
+}
+.hero-token__actions{display:flex;flex-wrap:wrap;gap:14px}
+.hero-token__btn{min-width:200px;text-align:center}
+.hero-token__btn.ghost{background:rgba(255,255,255,0.04);border-color:rgba(255,255,255,0.2)}
+.hero-token__btn.ghost:hover{background:rgba(255,255,255,0.12)}
+
+@media (max-width:1080px){
+  .hero-token__shell{grid-template-columns:minmax(0,1fr);text-align:left}
+  .hero-token__media{order:-1}
+  .hero-token__stats{grid-template-columns:repeat(auto-fit, minmax(160px,1fr))}
+}
+@media (max-width:720px){
+  .hero-token{padding:140px 0 90px}
+  .hero-token__shell{padding:32px;border-radius:32px}
+  .hero-token__media-card{border-radius:30px}
+  .hero-token__stat{padding:14px 16px}
+  .hero-token__contract{padding:20px}
+  .hero-token__contract-head{flex-direction:column;align-items:flex-start}
+  .hero-token__copy{width:100%;text-align:center}
+}
+@media (max-width:520px){
+  .hero-token{padding:120px 0 72px}
+  .hero-token__shell{padding:26px;border-radius:28px}
+  .hero-token__content .section-title{font-size:32px}
+  .hero-token__btn{flex:1;min-width:auto}
+  .hero-token__tag{left:18px;bottom:18px;padding:6px 14px;font-size:11px}
+  .hero-token__stats{gap:12px}
+}
+
 /* Token role block */
 .token-role .container{position:relative;z-index:1}
 .token-role__wrap{

--- a/tokenomics.html
+++ b/tokenomics.html
@@ -38,27 +38,46 @@
 <main>
 
   <!-- 1) Герой — Свиток чисел -->
-  <section id="hero-token" class="reveal" style="padding-top:140px">
+  <section id="hero-token" class="hero-token reveal">
     <div class="container">
-      <div class="grid cols-2">
-        <div class="feature-media">
-          <video autoplay muted loop playsinline poster="assets/city_girl.webp">
-            <source src="assets/feature_bg.mp4" type="video/mp4">
-          </video>
+      <div class="hero-token__shell">
+        <div class="hero-token__media">
+          <figure class="hero-token__media-card">
+            <img src="assets/photo_2025-09-22_11-34-07.jpg" alt="Силуэт на неоновой улице">
+            <figcaption class="hero-token__tag">Neon drip</figcaption>
+            <span class="hero-token__shine hero-token__shine--pink" aria-hidden="true"></span>
+            <span class="hero-token__shine hero-token__shine--violet" aria-hidden="true"></span>
+          </figure>
         </div>
-        <div>
+        <div class="hero-token__content">
+          <span class="hero-token__eyebrow">MEM-SCROLL ECONOMY</span>
           <h1 class="section-title">Токеномика $RAKODI</h1>
           <p class="section-sub">Мем-токен на стадии «памфан». Ничего лишнего: простая структура, прозрачные правила, упор на комьюнити. Дойдём до порога — перейдём на DEX.</p>
-          <div class="statbar" style="justify-content:flex-start">
-            <div class="stat"><b>Тикер</b>: $RAKODI</div>
-            <div class="stat"><b>Статус</b>: памфан</div>
-            <div class="stat"><b>Сеть</b>: [указать сеть]</div>
+          <div class="hero-token__stats">
+            <div class="hero-token__stat">
+              <span class="hero-token__stat-label">Тикер</span>
+              <span class="hero-token__stat-value">$RAKODI</span>
+            </div>
+            <div class="hero-token__stat">
+              <span class="hero-token__stat-label">Статус</span>
+              <span class="hero-token__stat-value">памфан</span>
+            </div>
+            <div class="hero-token__stat">
+              <span class="hero-token__stat-label">Сеть</span>
+              <span class="hero-token__stat-value">[указать сеть]</span>
+            </div>
           </div>
-          <div class="card" style="margin-top:10px">
-            <div class="badge" data-copy="#contract-address">Контракт: <span id="contract-address">[0x…]</span></div>
-            <div class="statbar" style="justify-content:flex-start;margin-top:10px">
-              <a class="btn small" href="#">Купить на памфан</a>
-              <a class="btn small ghost" href="#">Смотреть контракт</a>
+          <div class="hero-token__contract">
+            <div class="hero-token__contract-head">
+              <span class="hero-token__contract-label">Контракт</span>
+              <button class="hero-token__copy" type="button" data-copy="#contract-address">Скопировать</button>
+            </div>
+            <div class="hero-token__contract-body">
+              <span id="contract-address">[0x…]</span>
+            </div>
+            <div class="hero-token__actions">
+              <a class="btn hero-token__btn" href="#">Купить на памфан</a>
+              <a class="btn ghost hero-token__btn" href="#">Смотреть контракт</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the tokenomics hero section layout with a bespoke two-column composition featuring highlighted media, stats, and contract actions
- add dedicated styling for the redesigned hero including neon gradients, glassmorphism shells, and responsive behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1689d3f78832a94d97abd467aeaa9