### PR TITLE
Restore TLDR block styling on tokenomics page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -597,6 +597,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 }
 @media (max-width:540px){
   .token-params__value{font-size:16px}
+}
 /* Tokenomics — TLDR tiles */
 .tldr-section{position:relative;z-index:1}
 .tldr-shell{


### PR DESCRIPTION
## Summary
- close the media query around the token parameters mobile font-size rule
- ensure the TLDR tile styles are applied at all breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d173b69d30832ab804b8cbb7cb28fd