### PR TITLE
style: redesign DEX progress block

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -149,6 +149,67 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .stat{padding:10px 18px;border-radius:14px;background:var(--glass);border:var(--border);font-weight:700}
 .stat small{display:block;color:var(--muted);font-weight:500}
 
+.dex-track{position:relative;display:grid;gap:28px;margin-top:32px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));z-index:1}
+.dex-track--compact{gap:24px;margin-top:24px}
+.dex-track--compact .dex-track__card{padding:28px}
+.dex-track--compact .dex-track__header,
+.dex-track--compact .dex-progress__header{margin-bottom:20px}
+.dex-track--compact .dex-targets li{padding:16px 18px}
+.dex-track__card{position:relative;padding:32px;border-radius:28px;border:1px solid rgba(255,255,255,0.1);background:linear-gradient(160deg,rgba(22,20,48,0.94),rgba(10,9,28,0.86));box-shadow:0 30px 70px rgba(6,4,24,0.6);backdrop-filter:blur(18px);overflow:hidden;isolation:isolate}
+.dex-track__card::before,.dex-track__card::after{content:"";position:absolute;pointer-events:none;opacity:.55;filter:blur(0.2px)}
+.dex-track__card::before{inset:-32% auto auto -28%;width:240px;height:240px;background:radial-gradient(circle at 50% 50%,rgba(255,255,255,0.14),transparent 70%)}
+.dex-track__card::after{inset:auto -38% -62% 32%;width:260px;height:260px;background:radial-gradient(circle at 50% 50%,rgba(123,92,255,0.32),transparent 72%)}
+.dex-track__card--targets{background:
+  radial-gradient(120% 140% at 0% 0%,rgba(255,46,106,0.28),transparent 70%),
+  radial-gradient(120% 120% at 100% 18%,rgba(123,92,255,0.24),transparent 72%),
+  linear-gradient(155deg,rgba(20,18,46,0.95),rgba(9,8,28,0.86))}
+.dex-track__card--progress{background:
+  radial-gradient(140% 140% at 92% -6%,rgba(123,92,255,0.32),transparent 66%),
+  radial-gradient(120% 140% at 8% 120%,rgba(255,46,106,0.24),transparent 72%),
+  linear-gradient(160deg,rgba(16,15,42,0.95),rgba(8,8,26,0.86))}
+.dex-track__header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:24px}
+.dex-track__eyebrow{display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.14);text-transform:uppercase;letter-spacing:.14em;font-size:11px;font-weight:700;color:rgba(236,234,255,0.82)}
+.dex-track__tag{font-size:12px;color:rgba(220,220,244,0.72);text-align:right}
+.dex-targets{list-style:none;margin:0;padding:0;display:grid;gap:18px}
+.dex-targets li{display:flex;align-items:flex-start;gap:18px;padding:18px 20px;border-radius:22px;background:rgba(18,18,36,0.72);border:1px solid rgba(255,255,255,0.08);box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04)}
+.dex-targets__icon{display:grid;place-items:center;min-width:48px;height:48px;border-radius:16px;background:linear-gradient(135deg,rgba(255,46,106,0.85),rgba(123,92,255,0.78));box-shadow:0 12px 24px rgba(123,92,255,0.35);font-weight:800;letter-spacing:.08em;text-transform:uppercase;font-size:13px;color:#fff}
+.dex-targets__body{display:flex;flex-direction:column;gap:4px}
+.dex-targets__label{font-weight:700;font-size:16px;letter-spacing:.02em;color:#f5f3ff}
+.dex-targets__value{font-size:13px;color:rgba(214,214,240,0.78)}
+.dex-targets__status{margin-left:auto;padding:6px 12px;border-radius:999px;background:rgba(123,92,255,0.16);border:1px solid rgba(123,92,255,0.4);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:rgba(232,231,255,0.85)}
+.dex-progress__header{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:24px}
+.dex-progress__badge{display:inline-flex;align-items:center;gap:8px;padding:8px 16px;border-radius:999px;background:linear-gradient(135deg,rgba(255,46,106,0.95),rgba(123,92,255,0.78));letter-spacing:.12em;text-transform:uppercase;font-size:11px;font-weight:800;box-shadow:0 10px 24px rgba(255,46,106,0.28)}
+.dex-progress__tag{font-size:12px;color:rgba(214,214,240,0.72);text-align:right}
+.dex-progress__meter{position:relative;height:12px;border-radius:999px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);overflow:hidden}
+.dex-progress__value{position:absolute;inset:0;width:var(--progress,0%);border-radius:inherit;background:linear-gradient(90deg,var(--accent),var(--accent-2));box-shadow:0 0 28px rgba(123,92,255,0.36);transition:width .4s ease}
+.dex-progress__value::after{content:"";position:absolute;inset:0;background:linear-gradient(90deg,rgba(255,255,255,0.24),transparent 45%);mix-blend-mode:screen}
+.dex-progress__summary{margin:20px 0 16px;font-size:15px;color:#f4f4ff}
+.dex-progress__summary b{color:#fff}
+.dex-progress__summary i{color:rgba(214,214,240,0.82)}
+.dex-progress__chips{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:12px}
+.dex-chip{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.14);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:rgba(232,231,255,0.9)}
+.dex-progress__note{margin-top:12px;font-size:13px;line-height:1.55;color:rgba(214,214,240,0.78)}
+.dex-track__footnote{margin:22px auto 0;text-align:center;color:rgba(214,214,240,0.72)}
+
+@media (max-width:720px){
+  .dex-track{grid-template-columns:minmax(0,1fr)}
+}
+@media (max-width:580px){
+  .dex-track__header,
+  .dex-progress__header{flex-direction:column;align-items:flex-start;gap:12px}
+  .dex-track__tag,
+  .dex-progress__tag{text-align:left}
+}
+@media (max-width:560px){
+  .dex-targets li{flex-wrap:wrap;padding:16px 18px}
+  .dex-targets__status{margin-left:0}
+}
+@media (max-width:480px){
+  .dex-track__card{padding:26px}
+  .dex-progress__summary{font-size:14px}
+  .dex-track--compact .dex-track__card{padding:22px}
+}
+
 /* Tokenomics — cinematic hero */
 .hero-token{
   position:relative;

--- a/news.html
+++ b/news.html
@@ -151,11 +151,66 @@
   <section id="dex-short" class="reveal">
     <div class="container">
       <h2 class="section-title">Путь к DEX</h2>
-      <div class="card" style="padding:12px">
-        <div style="height:8px;border-radius:8px;background:var(--glass);border:var(--border);overflow:hidden"><div style="height:100%;width:0%;background:linear-gradient(90deg,var(--accent),var(--accent-2));"></div></div>
-        <p class="small" style="margin:6px 0 8px">Готовность: <b>[XX%]</b> • До порога осталось: <i>[кратко]</i></p>
-        <div class="statbar" style="justify-content:center"><span class="badge">MC</span><span class="badge">Холдеры</span><span class="badge">Ликвидность</span><span class="badge">Техготовность</span></div>
-        <p class="small">Сейчас торгуемся на памфан; расширенный функционал — после перехода на DEX.</p>
+      <div class="dex-track dex-track--compact">
+        <article class="dex-track__card dex-track__card--targets">
+          <div class="dex-track__header">
+            <span class="dex-track__eyebrow">Чекпоинты</span>
+            <span class="dex-track__tag">Еженедельный апдейт статуса</span>
+          </div>
+          <ul class="dex-targets">
+            <li>
+              <span class="dex-targets__icon">MC</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Рыночная капитализация</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">HLD</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Количество холдеров</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">LQ</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Ликвидность пула</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">TECH</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Техническая готовность</span>
+                <span class="dex-targets__value">Аудит/ревью, документация</span>
+              </div>
+              <span class="dex-targets__status">На ревью</span>
+            </li>
+          </ul>
+        </article>
+        <article class="dex-track__card dex-track__card--progress">
+          <div class="dex-progress">
+            <div class="dex-progress__header">
+              <span class="dex-progress__badge">Прогресс</span>
+              <span class="dex-progress__tag">Следим за динамикой в реальном времени</span>
+            </div>
+            <div class="dex-progress__meter" style="--progress:0%;">
+              <div class="dex-progress__value"></div>
+            </div>
+            <p class="dex-progress__summary">Готовность: <b>[XX%]</b> • До порога осталось: <i>[кратко]</i></p>
+            <div class="dex-progress__chips">
+              <span class="dex-chip">MC</span>
+              <span class="dex-chip">Холдеры</span>
+              <span class="dex-chip">Ликвидность</span>
+              <span class="dex-chip">Техготовность</span>
+            </div>
+            <p class="dex-progress__note">Сейчас торгуемся на памфан. Расширенный функционал включаем после перехода на DEX.</p>
+          </div>
+        </article>
       </div>
     </div>
   </section>

--- a/tokenomics.html
+++ b/tokenomics.html
@@ -337,22 +337,68 @@
   <section id="dex-path" class="reveal">
     <div class="container">
       <h2 class="section-title">Путь к DEX</h2>
-      <div class="grid cols-2">
-        <div class="card">
-          <ul>
-            <li><b>MC:</b> цель [—]</li>
-            <li><b>Холдеры:</b> цель [—]</li>
-            <li><b>Ликвидность:</b> цель [—]</li>
-            <li><b>Техготовность:</b> аудит/ревью, документация</li>
+      <div class="dex-track">
+        <article class="dex-track__card dex-track__card--targets">
+          <div class="dex-track__header">
+            <span class="dex-track__eyebrow">Чекпоинты</span>
+            <span class="dex-track__tag">Фиксируем путь по ключевым метрикам</span>
+          </div>
+          <ul class="dex-targets">
+            <li>
+              <span class="dex-targets__icon">MC</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Рыночная капитализация</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">HLD</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Количество холдеров</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">LQ</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Ликвидность пула</span>
+                <span class="dex-targets__value">Цель [—]</span>
+              </div>
+              <span class="dex-targets__status">В работе</span>
+            </li>
+            <li>
+              <span class="dex-targets__icon">TECH</span>
+              <div class="dex-targets__body">
+                <span class="dex-targets__label">Техническая готовность</span>
+                <span class="dex-targets__value">Аудит/ревью, документация</span>
+              </div>
+              <span class="dex-targets__status">На ревью</span>
+            </li>
           </ul>
-        </div>
-        <div class="card">
-          <h3>Прогресс</h3>
-          <div style="height:10px;border-radius:10px;background:var(--glass);border:var(--border);overflow:hidden"><div style="height:100%;width:0%;background:linear-gradient(90deg,var(--accent),var(--accent-2));"></div></div>
-          <p class="small" style="margin:6px 0 0">Готовность: <b>[XX%]</b> • Осталось по метрикам: [краткая строка]</p>
-        </div>
+        </article>
+        <article class="dex-track__card dex-track__card--progress">
+          <div class="dex-progress">
+            <div class="dex-progress__header">
+              <span class="dex-progress__badge">Прогресс</span>
+              <span class="dex-progress__tag">Обновляется по мере достижения чекпоинтов</span>
+            </div>
+            <div class="dex-progress__meter" style="--progress:0%;">
+              <div class="dex-progress__value"></div>
+            </div>
+            <p class="dex-progress__summary">Готовность: <b>[XX%]</b> • Осталось по метрикам: [краткая строка]</p>
+            <div class="dex-progress__chips">
+              <span class="dex-chip">MC</span>
+              <span class="dex-chip">Холдеры</span>
+              <span class="dex-chip">Ликвидность</span>
+              <span class="dex-chip">Техготовность</span>
+            </div>
+            <p class="dex-progress__note">Следим за динамикой и переходим на DEX, когда все индикаторы становятся зелёными.</p>
+          </div>
+        </article>
       </div>
-      <p class="small">Как только чекпоинты зелёные — объявляем процедуру перехода.</p>
+      <p class="dex-track__footnote small">Как только чекпоинты зелёные — объявляем процедуру перехода.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- restyled the “Путь к DEX” block with neon glassmorphism cards, progress meter and status chips
- reused the new layout on the news page and added component styles for compact and responsive views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d178bb8358832a85af11081d380ac1