### PR TITLE
Redesign transparency showcase on tokenomics page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1173,6 +1173,170 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .card h3{margin-top:0}
 .card .muted{color:var(--muted)}
 
+/* Transparency showcase */
+#transparency{position:relative;overflow:hidden}
+.transparency-shell{
+  position:relative;
+  display:grid;
+  gap:clamp(28px,4vw,44px);
+  padding:clamp(32px,6vw,64px);
+  border-radius:38px;
+  border:1px solid rgba(255,255,255,0.12);
+  background:
+    radial-gradient(140% 180% at 0% -20%, rgba(123,92,255,0.22), transparent 70%),
+    radial-gradient(160% 200% at 110% 20%, rgba(255,46,106,0.26), transparent 72%),
+    rgba(14,15,34,0.82);
+  box-shadow:0 36px 90px rgba(6,4,24,0.65);
+  backdrop-filter:blur(16px);
+  overflow:hidden;
+}
+.transparency-shell::before,
+.transparency-shell::after{
+  content:"";
+  position:absolute;
+  pointer-events:none;
+}
+.transparency-shell::before{
+  inset:auto -28% 48% 36%;
+  height:240px;
+  background:radial-gradient(circle at 50% 50%, rgba(255,255,255,0.12), transparent 70%);
+  opacity:.6;
+}
+.transparency-shell::after{
+  top:-140px;
+  right:-120px;
+  width:280px;
+  height:280px;
+  border-radius:50%;
+  background:linear-gradient(135deg, rgba(255,46,106,0.5), rgba(123,92,255,0.55));
+  opacity:.32;
+  filter:blur(48px);
+}
+.transparency-head{position:relative;z-index:1;display:grid;gap:12px;max-width:560px}
+.transparency-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.22);
+  background:rgba(10,12,26,0.68);
+  font-size:12px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  font-weight:700;
+}
+.transparency-chip::before{
+  content:"";
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 4px rgba(255,255,255,0.08);
+}
+.transparency-note{margin:0;color:var(--muted);font-size:16px;line-height:1.6;max-width:520px}
+.transparency-grid{position:relative;z-index:1;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:clamp(24px,4vw,34px)}
+.transparency-card{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
+  padding:clamp(24px,4vw,36px);
+  border-radius:28px;
+  border:1px solid rgba(255,255,255,0.14);
+  background:linear-gradient(160deg, rgba(9,11,24,0.88), rgba(18,10,30,0.72));
+  box-shadow:0 28px 70px rgba(5,4,22,0.45);
+  overflow:hidden;
+  isolation:isolate;
+  min-height:100%;
+}
+.transparency-card::before,
+.transparency-card::after{
+  content:"";
+  position:absolute;
+  pointer-events:none;
+  z-index:0;
+}
+.transparency-card::before{
+  inset:-140px 28% auto -34%;
+  height:240px;
+  background:radial-gradient(circle at 50% 50%, rgba(255,255,255,0.14), transparent 72%);
+  opacity:.55;
+}
+.transparency-card::after{
+  top:-40px;
+  right:-60px;
+  width:200px;
+  height:200px;
+  border-radius:50%;
+  background:linear-gradient(135deg, rgba(255,46,106,0.45), rgba(123,92,255,0.45));
+  opacity:.3;
+  filter:blur(40px);
+}
+.transparency-card__tag{
+  position:relative;
+  z-index:1;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 18px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.18);
+  background:rgba(255,255,255,0.06);
+  text-transform:uppercase;
+  letter-spacing:.18em;
+  font-size:12px;
+  font-weight:700;
+}
+.transparency-card__tag::before{
+  content:"";
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 4px rgba(255,255,255,0.08);
+}
+.transparency-list{
+  position:relative;
+  z-index:1;
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:16px;
+}
+.transparency-list li{
+  position:relative;
+  padding-left:30px;
+  line-height:1.6;
+  font-size:16px;
+  color:#f2f2f7;
+  font-weight:500;
+}
+.transparency-list li::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:0.78em;
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:linear-gradient(135deg,var(--accent),var(--accent-2));
+  box-shadow:0 0 0 5px rgba(255,255,255,0.06);
+  transform:translateY(-50%);
+}
+
+@media (max-width: 980px){
+  .transparency-shell{padding:clamp(28px,8vw,48px)}
+  .transparency-grid{grid-template-columns:1fr;gap:clamp(20px,6vw,30px)}
+}
+@media (max-width: 640px){
+  .transparency-shell{border-radius:28px}
+  .transparency-card{padding:clamp(22px,7vw,32px)}
+  .transparency-card__tag{font-size:11px;letter-spacing:.16em}
+  .transparency-note{font-size:15px}
+}
+
 /* Mission — cinematic infoblock */
 .mission-section{
   position:relative;

--- a/tokenomics.html
+++ b/tokenomics.html
@@ -359,20 +359,28 @@
   <!-- 10) Прозрачность и безопасность -->
   <section id="transparency" class="reveal">
     <div class="container">
-      <h2 class="section-title">Что открыто публично</h2>
-      <div class="grid cols-2">
-        <div class="card">
-          <ul>
-            <li>Адрес контракта и метаданные — закреплены на сайте и в соцсетях.</li>
-            <li>Исходник контракта — [верифицирован/ссылка].</li>
-            <li>Ончейн‑дашборды: цена, объём, холдеры, ликвидность.</li>
-          </ul>
+      <div class="transparency-shell">
+        <div class="transparency-head">
+          <span class="transparency-chip">Прозрачность</span>
+          <h2 class="section-title">Что открыто публично</h2>
+          <p class="transparency-note">Мы фиксируем ключевые параметры и обновляем статус, чтобы любой мог отследить прогресс без ожидания отчёта.</p>
         </div>
-        <div class="card">
-          <ul>
-            <li>Статус аудита/код‑ревью — [в процессе/готово/ссылка].</li>
-            <li>Коммуникации по изменениям — сначала анонс, затем действие.</li>
-          </ul>
+        <div class="transparency-grid">
+          <article class="transparency-card">
+            <span class="transparency-card__tag">Публичные данные</span>
+            <ul class="transparency-list">
+              <li>Адрес контракта и метаданные — закреплены на сайте и в соцсетях.</li>
+              <li>Исходник контракта — [верифицирован/ссылка].</li>
+              <li>Ончейн‑дашборды: цена, объём, холдеры, ликвидность.</li>
+            </ul>
+          </article>
+          <article class="transparency-card">
+            <span class="transparency-card__tag">Процессы и ревью</span>
+            <ul class="transparency-list">
+              <li>Статус аудита/код‑ревью — [в процессе/готово/ссылка].</li>
+              <li>Коммуникации по изменениям — сначала анонс, затем действие.</li>
+            </ul>
+          </article>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyled the "Что открыто публично" section with a bespoke transparency shell and tag layout
- added dedicated styles for the new transparency block, including responsive tweaks and gradient accents

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d179424118832aa4f6ba90844331e3