### PR TITLE
Refine rituals section presentation

### DIFF
--- a/brotherhood.html
+++ b/brotherhood.html
@@ -264,14 +264,33 @@
   <!-- 9) Ритуальный календарь -->
   <section id="rituals" class="reveal">
     <div class="container">
-      <h2 class="section-title">Ритуалы и события</h2>
-      <div class="grid cols-2">
-        <div class="card"><h3>Премьеры YouTube</h3><p class="muted">еженедельно/по расписанию — общий сбор в Telegram‑чате.</p></div>
-        <div class="card"><h3>Советы Скриптория</h3><p class="muted">раз в неделю — воркшоп по мемам и сценариям.</p></div>
-        <div class="card"><h3>Форум Консулов</h3><p class="muted">обсуждение приоритетов на неделю, открытые заметки.</p></div>
-        <div class="card"><h3>AMA/Гостевые стримы</h3><p class="muted">по анонсу — приглашённые друзья проекта.</p></div>
+      <div class="rituals-head">
+        <h2 class="section-title">Ритуалы и события</h2>
+        <p class="section-sub">Каждую неделю закрепляем легенду: собираемся на премьеры, прокачиваем сценарии, фиксируем приоритеты и зовём союзников на прямые эфиры.</p>
       </div>
-      <div class="hero-cta hero-cta--left hero-cta--tight"><a class="btn small" href="#">Следить за расписанием</a></div>
+      <div class="rituals-grid">
+        <article class="ritual-card">
+          <span class="ritual-card__meta">Видео-ритуал</span>
+          <h3 class="ritual-card__title">Премьеры YouTube</h3>
+          <p class="ritual-card__text">еженедельно/по расписанию — общий сбор в Telegram‑чате.</p>
+        </article>
+        <article class="ritual-card">
+          <span class="ritual-card__meta">Мастерская</span>
+          <h3 class="ritual-card__title">Советы Скриптория</h3>
+          <p class="ritual-card__text">раз в неделю — воркшоп по мемам и сценариям.</p>
+        </article>
+        <article class="ritual-card">
+          <span class="ritual-card__meta">Стратегия</span>
+          <h3 class="ritual-card__title">Форум Консулов</h3>
+          <p class="ritual-card__text">обсуждение приоритетов на неделю, открытые заметки.</p>
+        </article>
+        <article class="ritual-card">
+          <span class="ritual-card__meta">Прямой эфир</span>
+          <h3 class="ritual-card__title">AMA/Гостевые стримы</h3>
+          <p class="ritual-card__text">по анонсу — приглашённые друзья проекта.</p>
+        </article>
+      </div>
+      <div class="rituals-footer hero-cta hero-cta--left hero-cta--tight"><a class="btn small" href="#">Следить за расписанием</a></div>
     </div>
   </section>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -4464,9 +4464,108 @@ body.page-brotherhood section .section-sub{color:rgba(218,220,248,0.82)}
 .leaderboard-head .badge{display:flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:999px;background:rgba(15,16,32,0.7);border:1px solid rgba(255,255,255,0.14);font-weight:700;letter-spacing:.12em;text-transform:uppercase}
 .leaderboard-note{margin-top:4px;color:rgba(205,208,240,0.7)}
 
-.page-brotherhood #rituals{background:linear-gradient(170deg, rgba(8,10,26,0.94), rgba(7,8,22,0.84))}
-.page-brotherhood #rituals .grid{gap:clamp(24px,4vw,32px)}
-.page-brotherhood #rituals .card{padding:26px 24px;border-radius:22px;border:1px solid rgba(255,255,255,0.12);background:linear-gradient(150deg, rgba(255,255,255,0.1), rgba(7,8,22,0.72));box-shadow:0 28px 70px rgba(5,4,20,0.52)}
+.page-brotherhood #rituals{
+  background:
+    radial-gradient(920px 620px at 6% 0%, rgba(255,46,106,0.18), transparent 72%),
+    radial-gradient(760px 540px at 94% -10%, rgba(123,92,255,0.16), transparent 70%),
+    linear-gradient(180deg, rgba(8,10,26,0.94), rgba(6,7,20,0.88));
+  overflow:hidden;
+}
+.page-brotherhood #rituals::before{
+  content:"";
+  position:absolute;
+  inset:-160px auto auto -140px;
+  width:420px;
+  height:420px;
+  background:radial-gradient(circle at 50% 50%, rgba(255,46,106,0.32), transparent 70%);
+  opacity:.55;
+  pointer-events:none;
+  filter:blur(6px);
+}
+.page-brotherhood #rituals .container{position:relative;z-index:1}
+.page-brotherhood #rituals .section-title{margin-bottom:8px}
+.page-brotherhood #rituals .section-sub{max-width:560px;color:rgba(218,220,250,0.78)}
+
+.rituals-head{display:flex;flex-direction:column;gap:12px;margin-bottom:clamp(28px,5vw,40px)}
+.rituals-grid{display:grid;gap:clamp(18px,3vw,28px);grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+@media (min-width:960px){
+  .rituals-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+.ritual-card{
+  position:relative;
+  z-index:0;
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  padding:clamp(24px,3vw,32px);
+  border-radius:26px;
+  border:1px solid transparent;
+  background:
+    linear-gradient(160deg, rgba(18,20,46,0.94), rgba(8,9,26,0.86)) padding-box,
+    linear-gradient(135deg, rgba(255,46,106,0.58), rgba(123,92,255,0.5)) border-box;
+  box-shadow:0 32px 90px rgba(6,4,24,0.6);
+  overflow:hidden;
+  transition:transform .45s ease;
+}
+.ritual-card::after{
+  content:"";
+  position:absolute;
+  top:-38%;
+  right:-32%;
+  width:280px;
+  height:280px;
+  border-radius:50%;
+  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.55), transparent 68%);
+  opacity:.7;
+  pointer-events:none;
+  transition:transform .5s ease, opacity .5s ease;
+}
+.ritual-card::before{
+  content:"";
+  position:absolute;
+  bottom:-36%;
+  left:-26%;
+  width:220px;
+  height:220px;
+  border-radius:50%;
+  background:radial-gradient(circle at 50% 50%, rgba(255,46,106,0.42), transparent 70%);
+  opacity:.55;
+  pointer-events:none;
+  transition:transform .5s ease, opacity .5s ease;
+}
+.ritual-card:hover{transform:translateY(-6px)}
+.ritual-card:hover::after,
+.ritual-card:hover::before{transform:scale(1.08);opacity:.88}
+.ritual-card > *{position:relative;z-index:1}
+.ritual-card__meta{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 14px;
+  border-radius:999px;
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  color:rgba(236,234,255,0.74);
+  background:rgba(255,255,255,0.08);
+  border:1px solid rgba(255,255,255,0.16);
+  box-shadow:0 18px 38px rgba(8,6,24,0.55);
+}
+.ritual-card__title{margin:0;font-size:clamp(20px,2.6vw,24px);letter-spacing:.02em;color:#fff}
+.ritual-card__text{margin:0;color:rgba(220,222,250,0.78);font-size:15px;line-height:1.6}
+.rituals-footer{margin-top:clamp(24px,4vw,36px)}
+.rituals-footer .btn.small{
+  padding:10px 20px;
+  border-radius:16px;
+  font-size:14px;
+  background:linear-gradient(120deg, rgba(255,46,106,0.95), rgba(123,92,255,0.9));
+  box-shadow:0 24px 46px rgba(123,92,255,0.35);
+  transition:transform .35s ease, box-shadow .35s ease;
+}
+.rituals-footer .btn.small:hover{
+  transform:translateY(-2px);
+  box-shadow:0 28px 54px rgba(123,92,255,0.42);
+}
 
 .page-brotherhood #social{background:radial-gradient(820px 640px at 6% 0%, rgba(123,92,255,0.16), transparent 72%), linear-gradient(165deg, rgba(8,10,24,0.92), rgba(10,9,24,0.86))}
 .page-brotherhood #social .exchanges{gap:16px}


### PR DESCRIPTION
## Summary
- restructure the rituals block to include a descriptive lead-in and meta chips for each event
- apply bespoke neon styling, gradients, and hover motion to the rituals cards and CTA button

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d17c7dd3d8832aa7f2419e27e7d91b