### PR TITLE
Redesign canon journey block

### DIFF
--- a/brotherhood.html
+++ b/brotherhood.html
@@ -437,14 +437,33 @@
   <!-- 11) Путь в канон -->
   <section id="canon" class="reveal">
     <div class="container">
-      <h2 class="section-title">От идеи до канона</h2>
-      <div class="timeline">
-        <div class="milestone"><div class="when">1. Подача</div><div>публикуешь мем/гайд по правилам.</div></div>
-        <div class="milestone"><div class="when">2. Обсуждение</div><div>обратная связь в Арсенале мемов.</div></div>
-        <div class="milestone"><div class="when">3. Отбор</div><div>Смотрители и Архивариусы рекомендуют лучшие.</div></div>
-        <div class="milestone"><div class="when">4. Канон</div><div>витрина на сайте, шанс попасть в видео.</div></div>
+      <div class="canon-head">
+        <h2 class="section-title">От идеи до канона</h2>
+        <p class="section-sub">Каждый мем проходит прозрачный ритуал: от первой подачи до места в галерее Братства.</p>
       </div>
-      <p class="small">Правила коротко: остроумно, по делу, уважительно; указывай источники.</p>
+      <div class="canon-track">
+        <article class="canon-step">
+          <span class="canon-step__index">1</span>
+          <h3 class="canon-step__title">Подача</h3>
+          <p class="canon-step__text">Публикуешь мем или гайд по правилам Скриптория — с источниками и уважением к героям.</p>
+        </article>
+        <article class="canon-step">
+          <span class="canon-step__index">2</span>
+          <h3 class="canon-step__title">Обсуждение</h3>
+          <p class="canon-step__text">Получаешь обратную связь в Арсенале мемов, дорабатываешь деталь, усиливаешь посыл.</p>
+        </article>
+        <article class="canon-step">
+          <span class="canon-step__index">3</span>
+          <h3 class="canon-step__title">Отбор</h3>
+          <p class="canon-step__text">Смотрители и Архивариусы отмечают лучшие работы — формируют подборку для витрины.</p>
+        </article>
+        <article class="canon-step">
+          <span class="canon-step__index">4</span>
+          <h3 class="canon-step__title">Канон</h3>
+          <p class="canon-step__text">Работа попадает на сайт, становится частью архива и может засветиться в следующих видео.</p>
+        </article>
+      </div>
+      <p class="canon-note small">Правила коротко: остроумно, по делу, уважительно; обязательно указывай источники.</p>
     </div>
   </section>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -5075,11 +5075,42 @@ box-shadow:0 32px 80px rgba(6,6,28,0.55);backdrop-filter:blur(16px);overflow:hid
   }
 }
 
-.page-brotherhood #canon{background:linear-gradient(160deg, rgba(9,9,24,0.92), rgba(7,8,20,0.86))}
-.page-brotherhood #canon .timeline{padding-left:32px}
-.page-brotherhood #canon .timeline::before{left:16px;background:linear-gradient(180deg, var(--accent), transparent)}
-.page-brotherhood #canon .milestone{background:rgba(12,12,28,0.72);border:1px solid rgba(255,255,255,0.12);box-shadow:0 16px 40px rgba(5,4,20,0.48)}
-.page-brotherhood #canon .milestone .when{color:#fff;letter-spacing:.04em;text-transform:uppercase}
+.page-brotherhood #canon{background:linear-gradient(162deg, rgba(9,9,24,0.94), rgba(6,7,18,0.86))}
+.page-brotherhood #canon .canon-head{display:flex;align-items:flex-end;justify-content:space-between;gap:clamp(16px,4vw,26px);flex-wrap:wrap}
+.page-brotherhood #canon .canon-head .section-title{margin:0}
+.page-brotherhood #canon .canon-head .section-sub{margin:0;max-width:440px;color:rgba(214,216,250,0.76)}
+.page-brotherhood #canon .canon-track{position:relative;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:clamp(18px,3vw,24px);padding:clamp(40px,6vw,54px);margin-top:clamp(28px,4vw,36px);border-radius:36px;border:1px solid rgba(255,255,255,0.14);background:radial-gradient(120% 160% at 12% -16%, rgba(255,46,106,0.22), transparent 70%),radial-gradient(140% 160% at 88% 122%, rgba(123,92,255,0.22), transparent 75%),linear-gradient(160deg, rgba(13,14,34,0.94), rgba(7,8,20,0.86));box-shadow:0 40px 110px rgba(6,6,24,0.6);isolation:isolate}
+.page-brotherhood #canon .canon-track::before{content:"";position:absolute;z-index:0;top:clamp(56px,7vw,72px);left:clamp(60px,7vw,88px);right:clamp(60px,7vw,88px);height:2px;background:linear-gradient(90deg, rgba(255,46,106,0.65), rgba(123,92,255,0.45));opacity:.65;border-radius:999px}
+.page-brotherhood #canon .canon-step{--step-accent:rgba(255,46,106,0.82);--step-glow:rgba(255,46,106,0.36);position:relative;z-index:1;padding:clamp(36px,5vw,46px) clamp(18px,3vw,24px) clamp(28px,4vw,34px);border-radius:26px;border:1px solid rgba(255,255,255,0.08);background:linear-gradient(160deg, rgba(18,18,36,0.78), rgba(10,10,28,0.62));box-shadow:inset 0 0 0 1px rgba(255,255,255,0.04);text-align:center;transition:transform .3s ease, box-shadow .3s ease, border-color .3s ease;overflow:visible}
+.page-brotherhood #canon .canon-step::before{content:"";position:absolute;z-index:0;top:0;left:50%;transform:translate(-50%,-58%);width:clamp(78px,9vw,102px);height:clamp(78px,9vw,102px);background:radial-gradient(circle at 50% 50%, var(--step-glow), transparent 72%);opacity:.78;pointer-events:none}
+.page-brotherhood #canon .canon-step::after{content:"";position:absolute;inset:1px;border-radius:inherit;background:linear-gradient(150deg, rgba(255,255,255,0.06), transparent 60%);opacity:.55;pointer-events:none}
+.page-brotherhood #canon .canon-step:nth-child(2){--step-accent:rgba(88,185,255,0.82);--step-glow:rgba(88,185,255,0.34)}
+.page-brotherhood #canon .canon-step:nth-child(3){--step-accent:rgba(123,92,255,0.85);--step-glow:rgba(123,92,255,0.36)}
+.page-brotherhood #canon .canon-step:nth-child(4){--step-accent:rgba(255,197,66,0.82);--step-glow:rgba(255,197,66,0.32)}
+.page-brotherhood #canon .canon-step:hover{transform:translateY(-6px);border-color:rgba(255,255,255,0.18);box-shadow:0 22px 50px rgba(10,10,32,0.55)}
+.page-brotherhood #canon .canon-step__index{position:absolute;z-index:2;top:0;left:50%;transform:translate(-50%,-50%);display:grid;place-items:center;width:clamp(56px,6.8vw,68px);height:clamp(56px,6.8vw,68px);border-radius:20px;background:radial-gradient(circle at 32% 28%, rgba(255,255,255,0.22), transparent 60%),linear-gradient(140deg, var(--step-accent), rgba(255,255,255,0.05));border:1px solid rgba(255,255,255,0.22);box-shadow:0 18px 36px var(--step-glow);font-weight:800;letter-spacing:.08em;font-size:clamp(18px,2.4vw,20px);color:#fff}
+.page-brotherhood #canon .canon-step__title{margin:0 0 10px;font-size:clamp(20px,2.6vw,22px);letter-spacing:.06em;text-transform:uppercase;color:#f8f8ff}
+.page-brotherhood #canon .canon-step__text{margin:0;font-size:clamp(15px,2.2vw,17px);color:rgba(218,220,252,0.78);line-height:1.6}
+.page-brotherhood #canon .canon-note{margin-top:clamp(28px,4vw,36px);max-width:520px;color:rgba(210,213,244,0.72)}
+@media (max-width:1080px){
+  .page-brotherhood #canon .canon-track{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+@media (max-width:880px){
+  .page-brotherhood #canon .canon-track::before{left:clamp(36px,6vw,54px);right:clamp(36px,6vw,54px);top:clamp(58px,9vw,80px)}
+}
+@media (max-width:720px){
+  .page-brotherhood #canon .canon-head{align-items:flex-start}
+  .page-brotherhood #canon .canon-head .section-sub{max-width:none}
+  .page-brotherhood #canon .canon-track{grid-template-columns:minmax(0,1fr);padding:clamp(32px,8vw,44px) clamp(24px,7vw,36px);gap:clamp(22px,7vw,30px)}
+  .page-brotherhood #canon .canon-track::before{display:none}
+  .page-brotherhood #canon .canon-step{padding:clamp(32px,7vw,44px) clamp(18px,6vw,28px) clamp(26px,6vw,32px) clamp(32px,9vw,46px);text-align:left}
+  .page-brotherhood #canon .canon-step::before{left:clamp(36px,10vw,46px);transform:translate(-50%,-58%)}
+  .page-brotherhood #canon .canon-step__index{left:clamp(36px,10vw,46px);transform:translate(-50%,-50%)}
+}
+@media (max-width:520px){
+  .page-brotherhood #canon .canon-step{padding-left:clamp(28px,10vw,40px)}
+  .page-brotherhood #canon .canon-step__index{width:54px;height:54px;border-radius:18px;font-size:16px}
+}
 
 .page-brotherhood #voting{background:radial-gradient(860px 620px at 92% 10%, rgba(255,46,106,0.18), transparent 74%), linear-gradient(160deg, rgba(8,10,26,0.94), rgba(10,9,24,0.86))}
 .page-brotherhood #voting .grid{gap:clamp(24px,4vw,32px)}


### PR DESCRIPTION
## Summary
- replace the canon timeline markup with a card-based canon-track layout and refreshed copy
- add bespoke styling for the canon journey block with gradients, hover effects, and responsive tweaks

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1806f0460832a84411478b754a50e