### PR TITLE
style: refresh security section panels

### DIFF
--- a/brotherhood.html
+++ b/brotherhood.html
@@ -480,15 +480,22 @@
   <section id="security" class="reveal">
     <div class="container">
       <h2 class="section-title">Безопасность в крипте</h2>
-      <div class="grid cols-2">
-        <div class="card"><ul>
-          <li>Проверяй адрес контракта только на сайте и в официальных соцсетях.</li>
-          <li>Не переходи по случайным ссылкам, не раскрывай seed‑фразы.</li>
-        </ul></div>
-        <div class="card"><ul>
-          <li>Внимательно сверяй тикер $RAKODI: остерегайся клонов.</li>
-          <li>Любые изменения — сначала публичный анонс.</li>
-        </ul><p class="small">$RAKODI — мем‑токен; ничего здесь не является финсоветом (DYOR).</p></div>
+      <div class="security-panels">
+        <article class="security-card">
+          <span class="security-card__label">Проверяй источники</span>
+          <ul class="security-list">
+            <li>Проверяй адрес контракта только на сайте и в официальных соцсетях.</li>
+            <li>Не переходи по случайным ссылкам, не раскрывай seed‑фразы.</li>
+          </ul>
+        </article>
+        <article class="security-card security-card--accent">
+          <span class="security-card__label">Будь на чеку</span>
+          <ul class="security-list">
+            <li>Внимательно сверяй тикер $RAKODI: остерегайся клонов.</li>
+            <li>Любые изменения — сначала публичный анонс.</li>
+          </ul>
+          <p class="security-note">$RAKODI — мем‑токен; ничего здесь не является финсоветом (DYOR).</p>
+        </article>
       </div>
     </div>
   </section>

--- a/css/styles.css
+++ b/css/styles.css
@@ -5092,12 +5092,33 @@ box-shadow:0 32px 80px rgba(6,6,28,0.55);backdrop-filter:blur(16px);overflow:hid
 .page-brotherhood #code li::marker{color:var(--accent);font-weight:700}
 .page-brotherhood #code .small{margin-top:18px;color:rgba(205,208,240,0.72)}
 
-.page-brotherhood #security{background:radial-gradient(820px 560px at 18% 10%, rgba(123,92,255,0.2), transparent 74%), linear-gradient(160deg, rgba(8,10,24,0.94), rgba(7,8,22,0.84))}
-.page-brotherhood #security .grid{gap:clamp(24px,4vw,30px)}
-.page-brotherhood #security .card{padding:26px 24px;border-radius:24px;border:1px solid rgba(255,255,255,0.16);background:linear-gradient(150deg, rgba(255,255,255,0.12), rgba(7,8,22,0.76));box-shadow:0 30px 80px rgba(5,4,22,0.56)}
-.page-brotherhood #security ul{margin:0;padding-left:18px;display:grid;gap:10px;color:#e6e8ff}
-.page-brotherhood #security li::marker{color:var(--accent)}
-.page-brotherhood #security .small{margin-top:14px;color:rgba(205,208,240,0.7)}
+.page-brotherhood #security{position:relative;overflow:hidden;background:
+    radial-gradient(980px 640px at 12% 0%, rgba(123,92,255,0.24), transparent 70%),
+    radial-gradient(880px 560px at 88% -10%, rgba(255,46,106,0.2), transparent 74%),
+    linear-gradient(165deg, rgba(8,10,26,0.96), rgba(6,7,20,0.86))}
+.page-brotherhood #security::before,.page-brotherhood #security::after{content:"";position:absolute;inset:auto;pointer-events:none;filter:blur(0.2px);opacity:0.7}
+.page-brotherhood #security::before{top:-120px;left:-160px;width:320px;height:320px;background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.55), transparent 70%)}
+.page-brotherhood #security::after{bottom:-180px;right:-120px;width:360px;height:360px;background:radial-gradient(circle at 50% 50%, rgba(255,46,106,0.42), transparent 72%)}
+.page-brotherhood #security .security-panels{position:relative;z-index:1;display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:clamp(24px,4vw,32px)}
+.page-brotherhood #security .security-card{position:relative;padding:clamp(24px,4vw,34px);border-radius:32px;border:1px solid rgba(255,255,255,0.18);background:
+    linear-gradient(160deg, rgba(22,19,46,0.92), rgba(9,9,26,0.78));
+  box-shadow:0 32px 90px rgba(6,5,26,0.55);overflow:hidden;isolation:isolate;transition:transform .35s ease,border-color .35s ease;transform:translateZ(0)}
+.page-brotherhood #security .security-card::before{content:"";position:absolute;inset:-40% auto auto -30%;width:280px;height:280px;background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.35), transparent 72%);opacity:0.8;pointer-events:none;transition:transform .4s ease,opacity .4s ease}
+.page-brotherhood #security .security-card::after{content:"";position:absolute;inset:auto -40% -55% auto;width:260px;height:260px;background:radial-gradient(circle at 50% 50%, rgba(255,46,106,0.32), transparent 70%);opacity:0.8;pointer-events:none;transition:transform .4s ease,opacity .4s ease}
+.page-brotherhood #security .security-card:hover::before{opacity:1;transform:translate3d(10px,6px,0) scale(1.05)}
+.page-brotherhood #security .security-card:hover::after{opacity:1;transform:translate3d(-8px,-10px,0) scale(1.04)}
+.page-brotherhood #security .security-card__label{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:999px;background:rgba(255,255,255,0.12);border:1px solid rgba(255,255,255,0.2);letter-spacing:.16em;text-transform:uppercase;font-size:11px;font-weight:700;color:rgba(236,234,255,0.9);position:relative;z-index:1}
+.page-brotherhood #security .security-card--accent{background:
+    linear-gradient(165deg, rgba(24,12,32,0.92), rgba(9,9,26,0.78));
+  border-color:rgba(255,86,146,0.32)}
+.page-brotherhood #security .security-card--accent::before{background:radial-gradient(circle at 50% 50%, rgba(255,86,146,0.42), transparent 72%)}
+.page-brotherhood #security .security-card--accent::after{background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.45), transparent 74%)}
+.page-brotherhood #security .security-list{margin:22px 0 0;padding:0;list-style:none;display:grid;gap:14px;color:#edf0ff;position:relative;z-index:1}
+.page-brotherhood #security .security-list li{display:flex;gap:14px;font-size:clamp(16px,2.2vw,18px);line-height:1.55;letter-spacing:.01em}
+.page-brotherhood #security .security-list li::before{content:"";flex:none;width:12px;height:12px;border-radius:50%;margin-top:0.4em;background:linear-gradient(135deg, rgba(255,46,106,0.9), rgba(123,92,255,0.9));box-shadow:0 0 0 4px rgba(255,255,255,0.08)}
+.page-brotherhood #security .security-card--accent .security-list li::before{background:linear-gradient(135deg, rgba(123,92,255,0.95), rgba(86,196,255,0.9))}
+.page-brotherhood #security .security-note{margin-top:24px;font-size:13px;line-height:1.6;color:rgba(214,216,250,0.72);position:relative;z-index:1}
+.page-brotherhood #security .security-card:hover{transform:translateY(-6px)}
 
 .page-brotherhood #cta-join{background:
     radial-gradient(900px 620px at 92% -10%, rgba(255,46,106,0.24), transparent 74%),


### PR DESCRIPTION
## Summary
- restyled the "Безопасность в крипте" block with dedicated security panel markup
- created bespoke gradients, labels, and bullet styling to match the provided design

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d180dd0c2c832aacc9284da21d875a