### PR TITLE
Redesign mission hero and add language toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,10 +1,10 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="ru">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>RAKODI вЂ” РјРёРєСЂРѕСЂРѕСЏР»С‚Рё Рё СЃС‚СЂРёРјРёРЅРіРѕРІС‹Рµ РїР»Р°С‚РµР¶Рё РЅР° Solana</title>
-  <meta name="description" content="RAKODI вЂ” РёРЅРЅРѕРІР°С†РёРѕРЅРЅС‹Р№ С‚РѕРєРµРЅ СЌРєРѕСЃРёСЃС‚РµРјС‹ Solana РґР»СЏ РјРёРєСЂРѕСЂРѕСЏР»С‚Рё, РїРѕРґРїРёСЃРѕРє Рё СЃС‚СЂРёРјРёРЅРіРѕРІС‹С… РїР»Р°С‚РµР¶РµР№. Р”РµС†РµРЅС‚СЂР°Р»РёР·РѕРІР°РЅРЅР°СЏ СЌРєРѕРЅРѕРјРёРєР° РєСЂРµР°С‚РѕСЂРѕРІ Рё РёРіСЂ.">
+  <title>RAKODI — Миссия мем-города</title>
+  <meta name="description" content="RAKODI — город без координат. Узнай миссию мем-ордена, почувствуй кинематографичный лор и выбери точку входа в комьюнити Solana.">
   <link rel="icon" href="assets/20250922_1253_Neon_Visor_Monogram_remix_01k5r6fxgkeq7svghrvncrhmyv.png" type="image/png">
   <link rel="stylesheet" href="css/styles.css">
 </head>
@@ -21,14 +21,19 @@
     <div class="logo"><img src="assets/20250922_1253_Neon_Visor_Monogram_remix_01k5r6fxgkeq7svghrvncrhmyv.png" alt="RAKODI"><div class="brand">RAKODI</div></div>
     <button class="menu-toggle" aria-label="Меню"><span></span><span></span><span></span></button>
     <nav class="links">
-      <a href="index.html">Главная</a>
-      <a href="about.html">О проекте</a>
-      <a href="tokenomics.html">Токеномика</a>
-      <a href="brotherhood.html">Братство.</a>
-      <a href="news.html">Мемы</a>
+      <a href="index.html" data-i18n="nav.home">Главная</a>
+      <a href="about.html" data-i18n="nav.mission">Миссия</a>
+      <a href="tokenomics.html" data-i18n="nav.tokenomics">Токеномика</a>
+      <a href="brotherhood.html" data-i18n="nav.brotherhood">Братство.</a>
+      <a href="news.html" data-i18n="nav.news">Мемы</a>
     </nav>
     <div class="right">
-      <a class="btn small" href="#">Купить</a>
+      <button type="button" class="lang-toggle" data-current="ru" aria-label="Сменить язык" title="Сменить язык">
+        <span class="lang-toggle__option" data-lang-code="ru">RU</span>
+        <span class="lang-toggle__divider">/</span>
+        <span class="lang-toggle__option" data-lang-code="en">EN</span>
+      </button>
+      <a class="btn small" href="#" data-i18n="nav.buy">Купить</a>
       <a class="icon-btn" href="#" aria-label="Telegram"><img src="assets/telegram.svg" alt="Telegram"></a>
       <a class="icon-btn" href="#" aria-label="YouTube"><img src="assets/youtube.svg" alt="YouTube"></a>
     </div>
@@ -37,26 +42,61 @@
 
 <main>
 
-  <!-- 1) Кинематографический пролог — «Огонь, который помнит» -->
-  <section id="prologue" class="reveal">
+  <!-- 1) Миссия — кинематографичный город вне карт -->
+  <section id="mission-hero" class="mission-hero reveal">
+    <div class="mission-hero__backdrop" aria-hidden="true">
+      <span class="mission-hero__glow mission-hero__glow--one"></span>
+      <span class="mission-hero__glow mission-hero__glow--two"></span>
+      <span class="mission-hero__texture"></span>
+    </div>
     <div class="container">
-      <div class="prologue-layout">
-        <div class="prologue-content">
-          <span class="badge prologue-badge">Видео-пролог</span>
-          <h1 class="section-title">Ракоди — Новая Мем-Александрия</h1>
-          <p class="section-sub">Человечество снова собирает знания, энергию и идеи — теперь в криптосообществе. Мы превратили серьёзную легенду о сгоревшей библиотеке в ироничные мемы и рабочий механизм роста.</p>
-          <div class="hero-cta">
-            <a href="#" class="btn">Смотреть основное видео</a>
+      <div class="mission-hero__layout">
+        <div class="mission-hero__content">
+          <span class="mission-hero__tag" data-i18n="hero.tag">Миссия мем-ордена</span>
+          <h1 class="mission-hero__title" data-i18n-html="hero.title">RAKODI — <span class="mission-hero__accent">Город которого нет на картах.</span></h1>
+          <p class="mission-hero__lead" data-i18n-html="hero.lead"><span class="mission-hero__highlight">Живи, управляя своей судьбой, и смело тянись к звёздам.</span></p>
+          <p class="mission-hero__quote" data-i18n="hero.quote">Пусть разум будет твоим клинком, а сердце — пламенем, что направляет его к свету.</p>
+          <div class="mission-hero__cta">
+            <a href="#" class="btn" data-i18n="hero.primaryCta">Смотреть кинематографический тизер</a>
+            <a href="#legend" class="btn ghost" data-i18n="hero.secondaryCta">Читать легенду</a>
           </div>
-          <p class="small prologue-note">Видео-тизеры — наш язык. Они разжигают интерес, ведут на YouTube, а оттуда — в «нервный центр» проекта.</p>
-        </div>
-        <div class="prologue-media">
-          <div class="prologue-media__frame">
-            <video class="prologue-media__video" autoplay muted playsinline loop poster="assets/city_girl.webp">
-              <source src="assets/cyber-odisey.mp4" type="video/mp4">
-            </video>
+          <div class="mission-hero__meta">
+            <span data-i18n="hero.meta1">Видео • Мем-библиотека • Братство</span>
+            <span data-i18n="hero.meta2">Solana · community · орден мемов</span>
           </div>
         </div>
+        <aside class="mission-hero__card" aria-label="Сводка миссии">
+          <div class="mission-hero__card-head">
+            <span class="mission-hero__label" data-i18n="card.label">ЛОР-ДОСЬЕ</span>
+            <span class="mission-hero__season" data-i18n="card.season">Сезон I · «Возвращение огня»</span>
+          </div>
+          <div class="mission-hero__card-body">
+            <dl class="mission-hero__facts">
+              <div class="mission-hero__fact">
+                <dt data-i18n="card.stat1.title">Формат</dt>
+                <dd data-i18n="card.stat1.value">Кинематографичный мем-лор</dd>
+              </div>
+              <div class="mission-hero__fact">
+                <dt data-i18n="card.stat2.title">Статус</dt>
+                <dd data-i18n="card.stat2.value">Премьера в подготовке</dd>
+              </div>
+              <div class="mission-hero__fact">
+                <dt data-i18n="card.stat3.title">Цель</dt>
+                <dd data-i18n="card.stat3.value">Разжечь интерес и привести в Орден</dd>
+              </div>
+            </dl>
+            <div class="mission-hero__chips">
+              <span data-i18n="card.chip1">Solana</span>
+              <span data-i18n="card.chip2">Мем-библиотека</span>
+              <span data-i18n="card.chip3">Видео-релизы</span>
+            </div>
+            <p class="mission-hero__window" data-i18n="card.window">Следующий тизер · Октябрь 2024</p>
+          </div>
+          <div class="mission-hero__card-footer">
+            <span class="mission-hero__availability" data-i18n="card.availability">Точки входа: YouTube · Telegram · Братство</span>
+            <a href="#" class="mission-hero__play" data-i18n="card.play">Смотреть превью</a>
+          </div>
+        </aside>
       </div>
     </div>
   </section>

--- a/css/styles.css
+++ b/css/styles.css
@@ -59,6 +59,37 @@ header .right .btn.small{display:inline-flex;align-items:center;justify-content:
 .icon-btn{display:inline-flex;align-items:center;justify-content:center;min-width:auto;height:3vw;padding:0 1.2vw;border-radius:16px;border:none;background:transparent;box-shadow:var(--shadow)}
 .icon-btn img{width:1.2vw;height:1.2vw;display:block;object-fit:contain;filter:drop-shadow(0 2px 4px rgba(0,0,0,.2))}
 
+.lang-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:8px 14px;
+  border-radius:14px;
+  border:var(--border);
+  background:var(--glass);
+  color:#f4f4ff;
+  font-weight:700;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  cursor:pointer;
+  box-shadow:var(--shadow);
+  transition:background .3s ease, color .3s ease, box-shadow .3s ease;
+  backdrop-filter:blur(10px);
+}
+.lang-toggle:focus-visible{outline:2px solid rgba(255,255,255,0.6);outline-offset:2px}
+.lang-toggle:hover{background:linear-gradient(135deg,rgba(255,46,106,0.18),rgba(123,92,255,0.18));color:#fff}
+.lang-toggle__option{opacity:.52;transition:opacity .2s ease, color .2s ease;font-size:12px}
+.lang-toggle__divider{opacity:.35;font-size:12px;line-height:1}
+.lang-toggle.lang-ru .lang-toggle__option[data-lang-code="ru"],
+.lang-toggle.lang-en .lang-toggle__option[data-lang-code="en"]{
+  opacity:1;
+  color:#fff;
+}
+.lang-toggle.lang-ru{background:linear-gradient(135deg,rgba(255,46,106,0.22),rgba(123,92,255,0.14))}
+.lang-toggle.lang-en{background:linear-gradient(135deg,rgba(123,92,255,0.22),rgba(76,217,253,0.12))}
+.lang-toggle.lang-ru:hover,
+.lang-toggle.lang-en:hover{box-shadow:0 18px 38px rgba(8,4,28,0.55)}
+
 /* Responsive header layout */
 @media (max-width: 980px){
   .nav{gap:16px;flex-wrap:wrap}
@@ -136,6 +167,128 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .hero-h1{font-size:min(6.6vw,72px);line-height:1.05;margin:16px 0 12px}
 .hero-lead{color:#d7d7e4;max-width:900px;margin:0 auto 24px;font-size:18px}
 .hero-cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-top:6px}
+
+.mission-hero{
+  position:relative;
+  overflow:hidden;
+  padding:clamp(140px,24vw,240px) 0 clamp(120px,18vw,180px);
+  border-bottom:var(--border);
+  background:linear-gradient(140deg,rgba(9,10,24,0.88),rgba(10,8,28,0.92));
+}
+.mission-hero__backdrop{position:absolute;inset:0;pointer-events:none;overflow:hidden}
+.mission-hero__texture{
+  position:absolute;
+  inset:-18% -12% -12%;
+  background-image:linear-gradient(180deg,rgba(9,9,18,0.65),rgba(9,8,22,0.85)),url('../assets/city_girl.webp');
+  background-size:cover;
+  background-position:50% 48%;
+  opacity:0.42;
+  mix-blend-mode:screen;
+  filter:saturate(1.15) contrast(1.05) brightness(0.8);
+}
+.mission-hero__glow{
+  position:absolute;
+  width:520px;
+  height:520px;
+  border-radius:50%;
+  filter:blur(110px);
+  opacity:0.68;
+}
+.mission-hero__glow--one{top:-120px;left:-180px;background:radial-gradient(circle at 30% 30%,rgba(255,46,106,0.65),rgba(255,46,106,0) 70%)}
+.mission-hero__glow--two{bottom:-180px;right:-140px;background:radial-gradient(circle at 60% 40%,rgba(123,92,255,0.6),rgba(123,92,255,0) 75%)}
+.mission-hero__layout{position:relative;display:flex;gap:clamp(36px,7vw,96px);align-items:flex-end}
+.mission-hero__content{flex:1 1 54%;max-width:680px}
+.mission-hero__tag{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 16px;
+  border-radius:999px;
+  background:rgba(255,255,255,0.08);
+  border:1px solid rgba(255,255,255,0.16);
+  letter-spacing:.28em;
+  font-size:12px;
+  text-transform:uppercase;
+  color:rgba(238,238,255,0.9);
+}
+.mission-hero__title{font-size:clamp(42px,6.2vw,78px);line-height:1.05;margin:24px 0 18px;font-weight:800;text-transform:none}
+.mission-hero__accent{display:inline-block;background:linear-gradient(120deg,#fff,rgba(167,185,255,0.9));-webkit-background-clip:text;color:transparent}
+.mission-hero__lead{margin:0 0 16px;font-size:clamp(18px,2.1vw,24px);color:rgba(227,227,244,0.92);font-weight:600}
+.mission-hero__highlight{background:linear-gradient(120deg,#7b5cff,#9aa6ff,#d4e7ff);-webkit-background-clip:text;color:transparent}
+.mission-hero__quote{margin:0 0 28px;font-size:clamp(16px,1.6vw,20px);color:rgba(210,210,235,0.78);max-width:600px}
+.mission-hero__cta{display:flex;flex-wrap:wrap;gap:14px;margin-bottom:22px}
+.mission-hero__meta{display:flex;flex-wrap:wrap;gap:16px;color:rgba(210,210,240,0.65);font-size:13px;text-transform:uppercase;letter-spacing:.18em}
+.mission-hero__card{
+  flex:1 1 36%;
+  min-width:280px;
+  padding:32px;
+  border-radius:28px;
+  background:linear-gradient(160deg,rgba(17,15,38,0.92),rgba(9,8,26,0.9));
+  border:1px solid rgba(255,255,255,0.12);
+  box-shadow:0 32px 80px rgba(7,5,26,0.66);
+  backdrop-filter:blur(18px);
+  position:relative;
+  overflow:hidden;
+  isolation:isolate;
+}
+.mission-hero__card::after{
+  content:"";
+  position:absolute;
+  inset:-40% 20% auto -20%;
+  height:320px;
+  background:radial-gradient(circle at 50% 50%,rgba(255,46,106,0.24),transparent 72%);
+  opacity:.7;
+  pointer-events:none;
+}
+.mission-hero__card-head{display:flex;flex-direction:column;gap:8px;margin-bottom:26px}
+.mission-hero__label{font-size:12px;letter-spacing:.36em;text-transform:uppercase;color:rgba(255,255,255,0.62)}
+.mission-hero__season{font-size:clamp(16px,1.8vw,20px);font-weight:700;color:#fff}
+.mission-hero__facts{display:grid;gap:18px;margin:0 0 24px}
+.mission-hero__fact{display:grid;gap:6px}
+.mission-hero__fact dt{font-size:13px;letter-spacing:.24em;text-transform:uppercase;color:rgba(232,231,255,0.58)}
+.mission-hero__fact dd{margin:0;font-size:clamp(16px,1.8vw,20px);font-weight:700;color:#f8f8ff}
+.mission-hero__chips{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:20px}
+.mission-hero__chips span{padding:8px 14px;border-radius:999px;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.16);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:rgba(230,230,255,0.8)}
+.mission-hero__window{margin:0 0 28px;font-size:14px;color:rgba(220,220,245,0.7);letter-spacing:.12em;text-transform:uppercase}
+.mission-hero__card-footer{display:flex;flex-direction:column;gap:16px}
+.mission-hero__availability{font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:rgba(227,227,245,0.74)}
+.mission-hero__play{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  padding:12px 18px;
+  border-radius:14px;
+  background:linear-gradient(135deg,rgba(255,46,106,0.85),rgba(123,92,255,0.78));
+  color:#fff;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:.18em;
+  transition:transform .2s ease, box-shadow .2s ease;
+  box-shadow:0 16px 38px rgba(255,46,106,0.34);
+}
+.mission-hero__play:hover{transform:translateY(-2px);box-shadow:0 22px 46px rgba(123,92,255,0.38)}
+
+@media (max-width: 1180px){
+  .mission-hero__layout{flex-direction:column;align-items:flex-start}
+  .mission-hero__card{width:100%;max-width:560px}
+}
+@media (max-width: 820px){
+  .mission-hero{padding:clamp(120px,28vw,200px) 0 clamp(96px,22vw,140px)}
+  .mission-hero__meta{gap:10px;letter-spacing:.12em;font-size:12px}
+}
+@media (max-width: 620px){
+  .mission-hero__tag{font-size:11px;letter-spacing:.22em}
+  .mission-hero__title{font-size:clamp(36px,9vw,54px)}
+  .mission-hero__card{padding:26px;border-radius:24px}
+  .mission-hero__chips span{font-size:11px;letter-spacing:.14em}
+  .mission-hero__window{font-size:12px}
+}
+@media (max-width: 480px){
+  .mission-hero__meta{flex-direction:column}
+  .mission-hero__play{width:100%;text-align:center}
+  .mission-hero__lead{font-size:18px}
+}
 
 .parallax-layer{
   position:absolute;will-change:transform;transition:transform 0.1s;

--- a/js/script.js
+++ b/js/script.js
@@ -7,6 +7,129 @@ document.querySelectorAll('a[href^="#"]').forEach(a=>{
   });
 });
 
+// Language toggle
+const RAKODI_LANG_KEY = 'rakodi-lang';
+const translations = {
+  ru: {
+    'meta.title': 'RAKODI — Миссия мем-города',
+    'meta.description': 'RAKODI — город без координат. Узнай миссию мем-ордена, почувствуй кинематографичный лор и выбери точку входа в комьюнити Solana.',
+    'nav.home': 'Главная',
+    'nav.mission': 'Миссия',
+    'nav.tokenomics': 'Токеномика',
+    'nav.brotherhood': 'Братство.',
+    'nav.news': 'Мемы',
+    'nav.buy': 'Купить',
+    'hero.tag': 'Миссия мем-ордена',
+    'hero.title': 'RAKODI — <span class="mission-hero__accent">Город которого нет на картах.</span>',
+    'hero.lead': '<span class="mission-hero__highlight">Живи, управляя своей судьбой, и смело тянись к звёздам.</span>',
+    'hero.quote': 'Пусть разум будет твоим клинком, а сердце — пламенем, что направляет его к свету.',
+    'hero.primaryCta': 'Смотреть кинематографический тизер',
+    'hero.secondaryCta': 'Читать легенду',
+    'hero.meta1': 'Видео • Мем-библиотека • Братство',
+    'hero.meta2': 'Solana · community · орден мемов',
+    'card.label': 'ЛОР-ДОСЬЕ',
+    'card.season': 'Сезон I · «Возвращение огня»',
+    'card.stat1.title': 'Формат',
+    'card.stat1.value': 'Кинематографичный мем-лор',
+    'card.stat2.title': 'Статус',
+    'card.stat2.value': 'Премьера в подготовке',
+    'card.stat3.title': 'Цель',
+    'card.stat3.value': 'Разжечь интерес и привести в Орден',
+    'card.chip1': 'Solana',
+    'card.chip2': 'Мем-библиотека',
+    'card.chip3': 'Видео-релизы',
+    'card.window': 'Следующий тизер · Октябрь 2024',
+    'card.availability': 'Точки входа: YouTube · Telegram · Братство',
+    'card.play': 'Смотреть превью',
+    'lang.aria': 'Сменить язык',
+    'header.menu': 'Меню'
+  },
+  en: {
+    'meta.title': 'RAKODI — Mission of the Meme City',
+    'meta.description': 'RAKODI is a city without coordinates. Explore the mission of the meme order, feel the cinematic lore, and choose your entry into the Solana community.',
+    'nav.home': 'Home',
+    'nav.mission': 'Mission',
+    'nav.tokenomics': 'Tokenomics',
+    'nav.brotherhood': 'Brotherhood.',
+    'nav.news': 'Memes',
+    'nav.buy': 'Buy',
+    'hero.tag': 'Mission of the Meme Order',
+    'hero.title': 'RAKODI — <span class="mission-hero__accent">The City That Doesn’t Exist on Maps.</span>',
+    'hero.lead': '<span class="mission-hero__highlight">Live by steering your own destiny and boldly reach for the stars.</span>',
+    'hero.quote': 'Let your mind be the blade, and your heart the flame that directs it toward the light.',
+    'hero.primaryCta': 'Watch the cinematic teaser',
+    'hero.secondaryCta': 'Read the legend',
+    'hero.meta1': 'Videos • Meme Library • Brotherhood',
+    'hero.meta2': 'Solana · Community · Meme Order',
+    'card.label': 'LORE DOSSIER',
+    'card.season': 'Season I · “Return of the Flame”',
+    'card.stat1.title': 'Format',
+    'card.stat1.value': 'Cinematic meme lore',
+    'card.stat2.title': 'Status',
+    'card.stat2.value': 'Premiere in progress',
+    'card.stat3.title': 'Objective',
+    'card.stat3.value': 'Ignite curiosity and lead into the Order',
+    'card.chip1': 'Solana',
+    'card.chip2': 'Meme Library',
+    'card.chip3': 'Video drops',
+    'card.window': 'Next teaser · October 2024',
+    'card.availability': 'Entry points: YouTube · Telegram · Brotherhood',
+    'card.play': 'Play preview',
+    'lang.aria': 'Switch language',
+    'header.menu': 'Menu'
+  }
+};
+
+let currentLang = (typeof localStorage !== 'undefined' && localStorage.getItem(RAKODI_LANG_KEY) === 'en') ? 'en' : 'ru';
+
+function updateLangToggles(){
+  document.querySelectorAll('.lang-toggle').forEach(btn=>{
+    btn.dataset.current = currentLang;
+    btn.classList.toggle('lang-ru', currentLang === 'ru');
+    btn.classList.toggle('lang-en', currentLang === 'en');
+    const label = translations[currentLang]?.['lang.aria'] || '';
+    if(label){
+      btn.setAttribute('aria-label', label);
+      btn.setAttribute('title', label);
+    }
+  });
+}
+
+function applyLanguage(lang){
+  if(!translations[lang]) return;
+  currentLang = lang;
+  try{ localStorage.setItem(RAKODI_LANG_KEY, lang); }catch(e){ /* ignore */ }
+  document.documentElement.lang = lang;
+  document.title = translations[lang]['meta.title'];
+  const metaDesc = document.querySelector('meta[name="description"]');
+  if(metaDesc){ metaDesc.setAttribute('content', translations[lang]['meta.description']); }
+  const menuToggle = document.querySelector('.menu-toggle');
+  if(menuToggle){
+    const menuLabel = translations[lang]['header.menu'];
+    if(menuLabel) menuToggle.setAttribute('aria-label', menuLabel);
+  }
+  document.querySelectorAll('[data-i18n]').forEach(el=>{
+    const key = el.getAttribute('data-i18n');
+    const text = translations[lang][key];
+    if(typeof text === 'string') el.textContent = text;
+  });
+  document.querySelectorAll('[data-i18n-html]').forEach(el=>{
+    const key = el.getAttribute('data-i18n-html');
+    const html = translations[lang][key];
+    if(typeof html === 'string') el.innerHTML = html;
+  });
+  updateLangToggles();
+}
+
+applyLanguage(currentLang);
+
+document.addEventListener('click', (event)=>{
+  const toggle = event.target.closest('.lang-toggle');
+  if(!toggle) return;
+  event.preventDefault();
+  applyLanguage(currentLang === 'ru' ? 'en' : 'ru');
+});
+
 // Preloader (simple fade-out)
 window.addEventListener('load', ()=>{
   const pre = document.getElementById('preloader');


### PR DESCRIPTION
## Summary
- rename the mission page metadata and header navigation, and introduce a RU/EN language toggle in the header
- rebuild the opening mission hero block with cinematic layout, bilingual copy, and a lore card
- add styling and JavaScript translations to switch the hero and navigation between Russian and English

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9179ed7d4832a9cce989726077c38