### PR TITLE
Refine Pharos lighthouse block styling

### DIFF
--- a/assets/pharos-placeholder.svg
+++ b/assets/pharos-placeholder.svg
@@ -1,0 +1,40 @@
+<svg width="620" height="880" viewBox="0 0 620 880" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Pharos placeholder</title>
+  <desc id="desc">Abstract placeholder illustration of a lighthouse surrounded by waves.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#201522" />
+      <stop offset="50%" stop-color="#2c1c2f" />
+      <stop offset="100%" stop-color="#16131f" />
+    </linearGradient>
+    <linearGradient id="beam" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffdd8a" stop-opacity="0" />
+      <stop offset="40%" stop-color="#ffe6a6" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#fff3c6" stop-opacity="0.85" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="0%" r="70%">
+      <stop offset="0%" stop-color="#ffe9a8" stop-opacity="0.9" />
+      <stop offset="70%" stop-color="#ffdd8a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="620" height="880" fill="url(#bg)" rx="36" ry="36" />
+  <g opacity="0.85">
+    <path d="M90 736 Q310 620 530 736" fill="none" stroke="#4e3755" stroke-width="8" stroke-linecap="round" />
+    <path d="M110 768 Q310 660 510 768" fill="none" stroke="#3a2a3f" stroke-width="6" stroke-linecap="round" />
+    <path d="M130 802 Q310 708 490 802" fill="none" stroke="#2b1f30" stroke-width="6" stroke-linecap="round" />
+  </g>
+  <g transform="translate(180 120)">
+    <path d="M130 0 L200 0 L220 40 L110 40 Z" fill="#1c1624" stroke="#bfa464" stroke-width="4" />
+    <rect x="120" y="40" width="100" height="70" fill="#22192e" stroke="#bfa464" stroke-width="4" />
+    <rect x="140" y="110" width="60" height="40" fill="#271c33" stroke="#d5b76b" stroke-width="3" />
+    <path d="M170 150 L230 590 L110 590 Z" fill="#21182d" stroke="#c9a85b" stroke-width="4" />
+    <rect x="156" y="190" width="28" height="80" fill="#2f223f" stroke="#f4d27d" stroke-width="2" />
+    <rect x="156" y="310" width="28" height="80" fill="#2f223f" stroke="#f4d27d" stroke-width="2" />
+    <rect x="156" y="430" width="28" height="80" fill="#2f223f" stroke="#f4d27d" stroke-width="2" />
+    <circle cx="170" cy="88" r="28" fill="#ffe29b" opacity="0.4" />
+  </g>
+  <path d="M310 150 L620 260 L620 210 L310 100 Z" fill="url(#beam)" opacity="0.65" />
+  <circle cx="310" cy="150" r="160" fill="url(#glow)" opacity="0.45" />
+  <text x="50%" y="86%" text-anchor="middle" fill="#e0c888" font-family="'Cinzel', 'Times New Roman', serif" font-size="32" letter-spacing="6">PHAROS</text>
+  <text x="50%" y="91%" text-anchor="middle" fill="#8d6f3a" font-family="'Inter', 'Arial', sans-serif" font-size="18" letter-spacing="4">PLACEHOLDER ART</text>
+</svg>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1457,6 +1457,118 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 
 .buy-note strong{color:#ffd9e6;font-weight:700;}
 
+/* Trend — Pharos */
+.pharos-section{
+  position:relative;
+  padding:120px 0;
+  background:#020208;
+  overflow:hidden;
+  color:#f4e9d0;
+}
+.pharos-section__bg{
+  position:absolute;
+  inset:0;
+  background:radial-gradient(120% 120% at 50% 40%,rgba(187,138,74,0.24) 0%,rgba(60,41,74,0.14) 36%,rgba(14,9,21,0) 70%);
+  opacity:0.9;
+  pointer-events:none;
+}
+.pharos-shell{
+  position:relative;
+  display:grid;
+  grid-template-columns:minmax(0,0.92fr) minmax(0,1.1fr);
+  gap:60px;
+  align-items:stretch;
+}
+.pharos-visual{
+  margin:0;
+  display:flex;
+  flex-direction:column;
+  align-items:stretch;
+  gap:18px;
+  height:100%;
+}
+.pharos-visual__frame{
+  flex:1 1 auto;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:26px;
+  overflow:hidden;
+  background:linear-gradient(160deg,rgba(40,26,52,0.85),rgba(10,7,14,0.9));
+  box-shadow:0 34px 68px rgba(5,3,12,0.78);
+  height:100%;
+}
+.pharos-visual__frame img{
+  display:block;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.pharos-visual__caption{
+  font-size:14px;
+  text-transform:uppercase;
+  letter-spacing:0.42em;
+  color:rgba(244,233,208,0.55);
+  text-align:center;
+}
+.pharos-content{
+  display:flex;
+  flex-direction:column;
+  gap:28px;
+  padding:34px 36px 40px;
+}
+.pharos-header{margin:0;}
+.pharos-chip{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  padding:6px 16px;
+  border-radius:999px;
+  color:#f4e9d0;
+  font-size:13px;
+  letter-spacing:0.32em;
+  text-transform:uppercase;
+  background:linear-gradient(120deg,rgba(191,164,100,0.32),rgba(76,217,253,0.12));
+}
+.pharos-title{
+  margin:18px 0 8px;
+  font-size:42px;
+  line-height:1.12;
+  font-family:'Cinzel', 'Times New Roman', serif;
+  letter-spacing:0.08em;
+  color:#fbe8b4;
+}
+.pharos-subtitle{
+  margin:0;
+  font-size:18px;
+  letter-spacing:0.18em;
+  text-transform:uppercase;
+  color:rgba(244,233,208,0.7);
+}
+.pharos-text{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  font-size:16px;
+  line-height:1.7;
+  color:rgba(255,248,235,0.92);
+}
+.pharos-text p{margin:0;}
+
+@media (max-width:1100px){
+  .pharos-shell{grid-template-columns:1fr;gap:48px;}
+  .pharos-content{padding:24px 24px 32px;}
+  .pharos-title{font-size:36px;}
+}
+@media (max-width:640px){
+  .pharos-section{padding:88px 0;}
+  .pharos-content{padding:0 18px 28px;}
+  .pharos-title{font-size:30px;letter-spacing:0.05em;}
+  .pharos-subtitle{font-size:15px;letter-spacing:0.12em;}
+  .pharos-chip{font-size:11px;letter-spacing:0.24em;}
+}
+
+
 @media (max-width:1280px){
   .buy-grid{grid-template-columns:repeat(4,minmax(0,1fr));}
   .buy-card--wide{grid-column:span 4;flex-direction:column;}

--- a/index.html
+++ b/index.html
@@ -21,14 +21,19 @@
     <div class="logo"><img src="assets/20250922_1253_Neon_Visor_Monogram_remix_01k5r6fxgkeq7svghrvncrhmyv.png" alt="RAKODI"><div style="font-size: 1.6vw;" class="brand">RAKODI</div></div>
     <button class="menu-toggle" aria-label="Меню"><span></span><span></span><span></span></button>
     <nav class="links">
-      <a href="index.html">Главная</a>
-      <a href="about.html">О проекте</a>
-      <a href="tokenomics.html">Токеномика</a>
-      <a href="brotherhood.html">Братство.</a>
-      <a href="news.html">Мемы</a>
+      <a href="index.html" data-i18n="nav.home">Главная</a>
+      <a href="about.html" data-i18n="nav.mission">Миссия</a>
+      <a href="tokenomics.html" data-i18n="nav.tokenomics">Токеномика</a>
+      <a href="brotherhood.html" data-i18n="nav.brotherhood">Братство.</a>
+      <a href="news.html" data-i18n="nav.news">Мемы</a>
     </nav>
     <div class="right">
-      <a class="btn small" href="#">Купить</a>
+      <button type="button" class="lang-toggle" data-current="en" aria-label="Switch language" title="Switch language">
+        <span class="lang-toggle__option" data-lang-code="ru">RU</span>
+        <span class="lang-toggle__divider">/</span>
+        <span class="lang-toggle__option" data-lang-code="en">EN</span>
+      </button>
+      <a class="btn small" href="#" data-i18n="nav.buy">Купить</a>
       <a class="icon-btn" href="#" aria-label="Telegram"><img src="assets/telegram.svg" alt="Telegram"></a>
       <a class="icon-btn" href="#" aria-label="YouTube"><img src="assets/youtube.svg" alt="YouTube"></a>
     </div>
@@ -91,32 +96,28 @@
     </div>
   </section>
 
-  <!-- Видео (тизеры/клипы) -->
-  <section id="video" class="reveal">
-    <div class="container">
-      <h2 class="section-title">Видеотека</h2>
-      <p class="section-sub">Клиповые тизеры в стиле игровых и кинематографических трейлеров. Наша визуальная легенда.</p>
-      <div class="feature-media feature-media--showcase">
-        <div class="feature-media__inner">
-          <iframe
-            src="https://www.youtube.com/embed/abiL84EAWSY?si=tSqi2_liSB2K7lQu"
-            title="RAKODI — тизер"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            loading="lazy"
-            allowfullscreen
-          ></iframe>
+  <!-- Тренд I: Фаросский маяк -->
+  <section id="pharos" class="reveal pharos-section">
+    <div class="pharos-section__bg" aria-hidden="true"></div>
+    <div class="container pharos-shell">
+      <figure class="pharos-visual">
+        <div class="pharos-visual__frame">
+          <img src="assets/pharos-placeholder.svg" alt="Stylised illustration of the Lighthouse of Pharos" loading="lazy">
+        </div>
+        <figcaption class="pharos-visual__caption" data-i18n="pharos.caption">Light your beacon. Raise the signal.</figcaption>
+      </figure>
+      <div class="pharos-content">
+        <div class="pharos-header">
+          <span class="pharos-chip" data-i18n="pharos.chip">Trend I · Beacon Protocol</span>
+          <h2 class="pharos-title" data-i18n="pharos.title">The Lighthouse of Pharos</h2>
+          <p class="pharos-subtitle" data-i18n="pharos.subtitle">Switch on the torch, lift it high, and ignite your own beacon.</p>
+        </div>
+        <div class="pharos-text">
+          <p data-i18n="pharos.paragraph1">The Lighthouse of Pharos was not merely a tower of stone, but a voice of eternity speaking to humankind. Its light pierced through the darkness, whispering to sailors: “There is a path. Even if you are alone upon the boundless sea.” Born of human hands, yet touched by the divine, its radiance felt as though the universe itself was reaching out to those daring enough to sail beyond the horizon.</p>
+          <p data-i18n="pharos.paragraph2">For the ancient world, Pharos was a wonder, a living testament that human will and intellect could lift fire to the heavens. For us, it remains a symbol of hope, courage, and choice. Light can always be kindled, even in the deepest darkness, and once lit, it becomes a beacon for others to follow.</p>
+          <p data-i18n="pharos.paragraph3">Within each of us lies our own Pharos — an inner flame, capable not only of illuminating our own journey but also of inspiring those who walk beside us.</p>
         </div>
       </div>
-      <div class="grid cols-3" style="margin-top:14px">
-        <div class="card"><h3>Свитки будущего</h3><p class="muted">Короткий взгляд на путь комьюнити к DEX.</p></div>
-        <div class="card"><h3>Голоса зала</h3><p class="muted">Форумный вайб и огни неона.</p></div>
-        <div class="card"><h3>Пламя мемов</h3><p class="muted">Монтаж лучших моментов недели.</p></div>
-      </div>
-      <div class="hero-cta" style="margin-top:12px">
-        <a href="#" class="btn">Смотреть тизер</a>
-        <a href="#" class="btn ghost">Подписаться на YouTube</a>
-      </div>
-      <p class="small">Новые премьеры — по расписанию. Включи уведомления.</p>
     </div>
   </section>
 

--- a/js/script.js
+++ b/js/script.js
@@ -51,7 +51,14 @@ const translations = {
     'alexandria.detail2.text': 'Поэты, философы и учёные задавали пульс города, доказывая, что идеи — лучшая валюта, когда сообщество поддерживает их живыми.',
     'alexandria.detail3.label': 'Наследие Ракотиса',
     'alexandria.detail3.text': 'Память о Ракотисе вливается в Rakodi. Мы наследуем дух создателей, превращающих приморское поселение в маяк, устремлённый «ту зе мун».',
-    'alexandria.caption': 'Ту зе мун, Александр Македонский'
+    'alexandria.caption': 'Ту зе мун, Александр Македонский',
+    'pharos.chip': 'Тренд I · Протокол маяка',
+    'pharos.title': 'Фаросский маяк',
+    'pharos.subtitle': 'Включи фонарик, подними его и зажги свой маяк.',
+    'pharos.paragraph1': 'Маяк Фарос был не просто башней из камня, но голосом вечности, обращённым к людям. Его свет пронзал мрак, шепча морякам: «Путь есть. Даже если ты один посреди безграничного моря». Он был создан человеком, но в его сиянии чувствовалось присутствие богов — словно сама Вселенная протягивала руку тем, кто осмеливался выйти за горизонт.',
+    'pharos.paragraph2': 'Для древнего мира Фарос был чудом света, воплощением веры в то, что человеческий разум и воля способны вознести огонь к небесам. Для нас он остаётся символом надежды, мужества и выбора. Свет всегда можно зажечь, даже когда вокруг тьма, и именно он способен стать ориентиром для других.',
+    'pharos.paragraph3': 'Каждый человек носит в себе свой собственный Фарос — внутренний огонь, который способен не только освещать дорогу самому, но и вдохновлять тех, кто идёт рядом.',
+    'pharos.caption': 'Зажги маяк. Подними сигнал.'
   },
   en: {
     'meta.title': 'RAKODI — Mission of the Meme City',
@@ -94,7 +101,14 @@ const translations = {
     'alexandria.detail2.text': 'Poets, philosophers, and scientists shaped the city’s pulse — proving that ideas can be the greatest currency when a community keeps them alive.',
     'alexandria.detail3.label': 'Legacy of Rakotis',
     'alexandria.detail3.text': 'The memory of Rakotis flows into Rakodi. We inherit the spirit of builders who transform a coastal settlement into a beacon that reaches “to the moon.”',
-    'alexandria.caption': 'To the moon, Alexander the Great'
+    'alexandria.caption': 'To the moon, Alexander the Great',
+    'pharos.chip': 'Trend I · Beacon Protocol',
+    'pharos.title': 'The Lighthouse of Pharos',
+    'pharos.subtitle': 'Switch on the torch, lift it high, and ignite your own beacon.',
+    'pharos.paragraph1': 'The Lighthouse of Pharos was not merely a tower of stone, but a voice of eternity speaking to humankind. Its light pierced through the darkness, whispering to sailors: “There is a path. Even if you are alone upon the boundless sea.” Born of human hands, yet touched by the divine, its radiance felt as though the universe itself was reaching out to those daring enough to sail beyond the horizon.',
+    'pharos.paragraph2': 'For the ancient world, Pharos was a wonder, a living testament that human will and intellect could lift fire to the heavens. For us, it remains a symbol of hope, courage, and choice. Light can always be kindled, even in the deepest darkness, and once lit, it becomes a beacon for others to follow.',
+    'pharos.paragraph3': 'Within each of us lies our own Pharos — an inner flame, capable not only of illuminating our own journey but also of inspiring those who walk beside us.',
+    'pharos.caption': 'Light your beacon. Raise the signal.'
   }
 };
 


### PR DESCRIPTION
## Summary
- simplify the Pharos trend layout by removing the extra callout cards and redundant frames
- stretch the lighthouse artwork to mirror the text column height and rebalance spacing/padding
- darken the section backdrop to black-edged gradient and clean up translations to match the new structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da4333d724832aac1ce3bf8eaf72f2