### PR TITLE
Adjust mission page Pharos block styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -91,15 +91,17 @@
         <figcaption class="pharos-visual__caption" data-i18n="pharos.caption">Light your beacon. Raise the signal.</figcaption>
       </figure>
       <div class="pharos-content">
-        <div class="pharos-header">
-          <span class="pharos-chip" data-i18n="pharos.chip">Trend I · Beacon Protocol</span>
-          <h2 class="pharos-title" data-i18n="pharos.title">The Lighthouse of Pharos</h2>
-          <p class="pharos-subtitle" data-i18n="pharos.subtitle">Switch on the torch, lift it high, and ignite your own beacon.</p>
-        </div>
-        <div class="pharos-text">
-          <p data-i18n="pharos.paragraph1">The Lighthouse of Pharos was not merely a tower of stone, but a voice of eternity speaking to humankind. Its light pierced through the darkness, whispering to sailors: “There is a path. Even if you are alone upon the boundless sea.” Born of human hands, yet touched by the divine, its radiance felt as though the universe itself was reaching out to those daring enough to sail beyond the horizon.</p>
-          <p data-i18n="pharos.paragraph2">For the ancient world, Pharos was a wonder, a living testament that human will and intellect could lift fire to the heavens. For us, it remains a symbol of hope, courage, and choice. Light can always be kindled, even in the deepest darkness, and once lit, it becomes a beacon for others to follow.</p>
-          <p data-i18n="pharos.paragraph3">Within each of us lies our own Pharos — an inner flame, capable not only of illuminating our own journey but also of inspiring those who walk beside us.</p>
+        <div class="pharos-panel">
+          <div class="pharos-header">
+            <span class="pharos-chip" data-i18n="pharos.chip">Trend I · Beacon Protocol</span>
+            <h2 class="pharos-title" data-i18n="pharos.title">The Lighthouse of Pharos</h2>
+            <p class="pharos-subtitle" data-i18n="pharos.subtitle">Switch on the torch, lift it high, and ignite your own beacon.</p>
+          </div>
+          <div class="pharos-text">
+            <p data-i18n="pharos.paragraph1">The Lighthouse of Pharos was not merely a tower of stone, but a voice of eternity speaking to humankind. Its light pierced through the darkness, whispering to sailors: “There is a path. Even if you are alone upon the boundless sea.” Born of human hands, yet touched by the divine, its radiance felt as though the universe itself was reaching out to those daring enough to sail beyond the horizon.</p>
+            <p data-i18n="pharos.paragraph2">For the ancient world, Pharos was a wonder, a living testament that human will and intellect could lift fire to the heavens. For us, it remains a symbol of hope, courage, and choice. Light can always be kindled, even in the deepest darkness, and once lit, it becomes a beacon for others to follow.</p>
+            <p data-i18n="pharos.paragraph3">Within each of us lies our own Pharos — an inner flame, capable not only of illuminating our own journey but also of inspiring those who walk beside us.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1465,6 +1465,9 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   overflow:hidden;
   color:#f4e9d0;
 }
+.mission-page .pharos-section{
+  background:transparent;
+}
 .pharos-section__bg{
   position:absolute;
   inset:0;
@@ -1484,6 +1487,48 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   grid-template-columns:minmax(0,0.92fr) minmax(0,1.1fr);
   gap:60px;
   align-items:stretch;
+}
+.mission-page .pharos-content{
+  padding:0;
+}
+.mission-page .pharos-panel{
+  position:relative;
+  overflow:hidden;
+  background:rgba(5,4,10,0.88);
+  border:1px solid rgba(204,164,104,0.65);
+  box-shadow:0 26px 60px rgba(8,4,16,0.6);
+  border-radius:30px;
+  padding:38px 42px 44px;
+  backdrop-filter:blur(8px);
+}
+.mission-page .pharos-panel::before{
+  content:"";
+  position:absolute;
+  inset:10px;
+  border-radius:22px;
+  border:1px solid rgba(255,215,156,0.28);
+  pointer-events:none;
+}
+.mission-page .pharos-panel::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(140% 160% at 20% 10%,rgba(255,201,126,0.12),rgba(12,8,18,0));
+  pointer-events:none;
+}
+.mission-page .pharos-visual__frame{
+  border:1px solid rgba(204,164,104,0.65);
+  border-radius:30px;
+  box-shadow:0 28px 60px rgba(12,6,18,0.56);
+  position:relative;
+}
+.mission-page .pharos-visual__frame::after{
+  content:"";
+  position:absolute;
+  inset:12px;
+  border-radius:22px;
+  border:1px solid rgba(255,215,156,0.25);
+  pointer-events:none;
 }
 .pharos-visual{
   margin:0;


### PR DESCRIPTION
## Summary
- remove the dark background from the mission page Pharos section and wrap the text content in a gold-trimmed dark panel
- add complementary gold-framed styling around the lighthouse image for visual consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da4d7b20e4832a801c94d8d5a2c86c