### PR TITLE
Align Pharos media with text and clamp site width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -19,7 +19,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html,body{height:100%;max-width:100vw;overflow-x:hidden}
 html{scroll-behavior:smooth}
 body{
   margin:0;
@@ -1537,6 +1537,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   align-items:stretch;
   gap:18px;
   height:100%;
+  padding:34px 36px 40px;
 }
 .pharos-visual__frame{
   flex:1 1 auto;
@@ -1609,11 +1610,13 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:1100px){
   .pharos-shell{grid-template-columns:1fr;gap:48px;}
   .pharos-content{padding:24px 24px 32px;}
+  .pharos-visual{padding:24px 24px 32px;}
   .pharos-title{font-size:36px;}
 }
 @media (max-width:640px){
   .pharos-section{padding:88px 0;}
   .pharos-content{padding:0 18px 28px;}
+  .pharos-visual{padding:0 18px 28px;}
   .pharos-title{font-size:30px;letter-spacing:0.05em;}
   .pharos-subtitle{font-size:15px;letter-spacing:0.12em;}
   .pharos-chip{font-size:11px;letter-spacing:0.24em;}


### PR DESCRIPTION
## Summary
- pad the Pharos lighthouse figure so the image and caption fill the same height as the adjacent text column across breakpoints
- clamp the document width to the viewport and keep horizontal scrolling disabled site-wide

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68da4fa75740832aae42abda626850ca