### PR TITLE
Add mission page cinematic video carousel

### DIFF
--- a/about.html
+++ b/about.html
@@ -107,102 +107,96 @@
     </div>
   </section>
 
-  <!-- 4) Экосистема — «Нервный центр и сигнальные башни» -->
-  <section id="ecosystem" class="reveal">
+  <!-- 4) Сигнальная карусель — «Синематика маяков» -->
+  <section id="mission-cinema" class="reveal mission-cinema">
     <div class="container">
-      <h2 class="section-title">Как всё соединено</h2>
-      <p class="section-sub">Орбитальная схема показывает, как каждый канал ловит внимание и возвращает его в нервный центр экосистемы.</p>
+      <div class="mission-cinema__heading">
+        <span class="mission-cinema__chip" data-i18n="cinema.chip">Signal Cinema</span>
+        <h2 class="mission-cinema__title" data-i18n="cinema.title">Keepers of the Raised Light</h2>
+        <p class="mission-cinema__subtitle" data-i18n="cinema.subtitle">A gentle Hellenistic carousel that holds our core film and the torchlifting trend.</p>
+      </div>
 
-      <div class="ecosystem-diagram">
-        <svg class="ecosystem-links" viewBox="0 0 800 600" aria-hidden="true" focusable="false">
-          <defs>
-            <linearGradient id="ecosystem-line" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stop-color="rgba(255,46,106,0.85)"/>
-              <stop offset="50%" stop-color="rgba(123,92,255,0.65)"/>
-              <stop offset="100%" stop-color="rgba(76,217,253,0.6)"/>
-            </linearGradient>
-            <radialGradient id="ecosystem-core" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stop-color="rgba(255,46,106,0.8)"/>
-              <stop offset="60%" stop-color="rgba(123,92,255,0.25)"/>
-              <stop offset="100%" stop-color="rgba(12,16,32,0)"/>
-            </radialGradient>
-            <radialGradient id="ecosystem-orbit" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stop-color="rgba(255,255,255,0.22)"/>
-              <stop offset="70%" stop-color="rgba(255,255,255,0.02)"/>
-              <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
-            </radialGradient>
-          </defs>
-          <circle cx="400" cy="300" r="188" fill="none" stroke="url(#ecosystem-line)" stroke-width="1.4" stroke-dasharray="10 18" opacity="0.55" class="ecosystem-orbit"/>
-          <circle cx="400" cy="300" r="262" fill="none" stroke="url(#ecosystem-line)" stroke-width="1.1" stroke-dasharray="12 26" opacity="0.35" class="ecosystem-orbit"/>
-          <circle cx="400" cy="300" r="118" fill="url(#ecosystem-orbit)" opacity="0.5"/>
-          <path d="M400 300 C 332 236 260 198 170 158" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
-          <path d="M400 300 C 336 352 280 398 188 426" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
-          <path d="M400 300 C 476 266 542 238 604 260" stroke="url(#ecosystem-line)" stroke-width="2.4" fill="none" stroke-linecap="round" class="ecosystem-line"/>
-          <circle cx="400" cy="300" r="74" fill="url(#ecosystem-core)" opacity="0.7"/>
-        </svg>
-
-        <article class="ecosystem-node ecosystem-node--site">
-          <span class="ecosystem-chip">Главный узел</span>
-          <h3>Сайт — нервный центр</h3>
-          <p>Живые метрики, токеномика, квесты и база знаний. Сюда стекается весь внешний трафик и превращается в участие.</p>
-          <ul class="ecosystem-meta">
-            <li>открытая аналитика и дашборды</li>
-            <li>документация и onboarding для Братства</li>
-          </ul>
+      <div class="mission-cinema__intro">
+        <article class="mission-cinema__intro-card">
+          <h3 class="mission-cinema__intro-title" data-i18n="cinema.intro1.title">Signal Choreography</h3>
+          <p class="mission-cinema__intro-text" data-i18n="cinema.intro1.text">Placeholder copy about how we align the raised lights, shaping moodboards and storyboards for every drop.</p>
         </article>
-
-        <article class="ecosystem-node ecosystem-node--youtube">
-          <span class="ecosystem-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" role="presentation" focusable="false">
-              <circle cx="16" cy="16" r="13.2" stroke="currentColor" stroke-width="2" opacity="0.6" fill="none"/>
-              <path d="M13 11.5L21 16L13 20.5V11.5Z" fill="currentColor"/>
-            </svg>
-          </span>
-          <h3>YouTube — медиаядро</h3>
-          <p>Клиповые тизеры, прямые эфиры и коллаборации. Эмоция зажигает внимание и ведёт к подробностям на сайте.</p>
-          <span class="ecosystem-note">Трейлеры • Бэкстейдж • Прямые стримы</span>
-        </article>
-
-        <article class="ecosystem-node ecosystem-node--social">
-          <span class="ecosystem-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" role="presentation" focusable="false">
-              <circle cx="10" cy="10" r="4" stroke="currentColor" stroke-width="2" fill="none"/>
-              <circle cx="22" cy="8" r="3" fill="currentColor" opacity="0.7"/>
-              <circle cx="24" cy="22" r="4" stroke="currentColor" stroke-width="2" fill="none"/>
-              <circle cx="9" cy="23" r="3" fill="currentColor" opacity="0.7"/>
-              <path d="M12.5 12.5L19 20" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
-              <path d="M13 8L19 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
-              <path d="M20 22L22 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
-            </svg>
-          </span>
-          <h3>Соцсети — сетка сигналов</h3>
-          <p>X, Instagram и Reddit ловят новые аудитории. Усиливаем охват и возвращаем людей к видео и на сайт.</p>
-          <span class="ecosystem-note">Кросс-постинг • Мемы • Анонсы и спойлеры</span>
+        <article class="mission-cinema__intro-card">
+          <h3 class="mission-cinema__intro-title" data-i18n="cinema.intro2.title">City Pulse Notes</h3>
+          <p class="mission-cinema__intro-text" data-i18n="cinema.intro2.text">Another placeholder about the creative labs that polish edits, color, and lore before the beacon goes live.</p>
         </article>
       </div>
 
-      <div class="ecosystem-flow">
-        <div class="flow-step">
-          <span class="flow-index">01</span>
-          <h4>Контент зажигает</h4>
-          <p>Видео и мемы создают эмоциональный вход. Основные CTA ведут на сайт и в Telegram.</p>
+      <div class="mission-cinema__carousel" data-carousel tabindex="0">
+        <button class="mission-cinema__nav mission-cinema__nav--prev" type="button" data-carousel-prev>
+          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+            <path d="M14.5 6.5L9 12l5.5 5.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span class="visually-hidden" data-i18n="cinema.prev">Previous video</span>
+        </button>
+        <div class="mission-cinema__viewport">
+          <div class="mission-cinema__track" data-carousel-track>
+            <article class="mission-cinema__slide" data-carousel-slide>
+              <div class="mission-cinema__frame">
+                <iframe src="https://www.youtube.com/embed/ysz5S6PUM-U" title="Rakodi: Light Over the City" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+              </div>
+              <div class="mission-cinema__meta">
+                <span class="mission-cinema__tag" data-i18n="cinema.slide1.tag">Project Film</span>
+                <h3 class="mission-cinema__slide-title" data-i18n="cinema.slide1.title">Rakodi: Light Over the City</h3>
+                <p class="mission-cinema__slide-text" data-i18n="cinema.slide1.text">Cinematic core teaser with sweeping shots of the invisible city rising under a sea of torches.</p>
+              </div>
+            </article>
+
+            <article class="mission-cinema__slide" data-carousel-slide>
+              <div class="mission-cinema__frame">
+                <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Torch Trend Compilation" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+              </div>
+              <div class="mission-cinema__meta">
+                <span class="mission-cinema__tag" data-i18n="cinema.slide2.tag">Beacon Trend</span>
+                <h3 class="mission-cinema__slide-title" data-i18n="cinema.slide2.title">Torch Trend Compilation</h3>
+                <p class="mission-cinema__slide-text" data-i18n="cinema.slide2.text">Quick-cut reel of creators lifting the light upward — mood, energy, and pure meme momentum.</p>
+              </div>
+            </article>
+
+            <article class="mission-cinema__slide" data-carousel-slide>
+              <div class="mission-cinema__frame">
+                <iframe src="https://www.youtube.com/embed/aqz-KE-bpKQ" title="Beacon POV Sequence" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+              </div>
+              <div class="mission-cinema__meta">
+                <span class="mission-cinema__tag" data-i18n="cinema.slide3.tag">Beacon Trend</span>
+                <h3 class="mission-cinema__slide-title" data-i18n="cinema.slide3.title">Beacon POV Sequence</h3>
+                <p class="mission-cinema__slide-text" data-i18n="cinema.slide3.text">Immersive point-of-view of the raised flashlight ritual, stitched with crowd reactions and synth swells.</p>
+              </div>
+            </article>
+          </div>
         </div>
-        <div class="flow-step">
-          <span class="flow-index">02</span>
-          <h4>Сайт собирает</h4>
-          <p>Цифры, легенда и механики удерживают внимание, конвертируя его в регистрацию и покупку токена.</p>
-        </div>
-        <div class="flow-step">
-          <span class="flow-index">03</span>
-          <h4>Комьюнити усиливает</h4>
-          <p>Телеграм и соцсети возвращают инсайты в контент, замыкая петлю роста.</p>
-        </div>
+        <button class="mission-cinema__nav mission-cinema__nav--next" type="button" data-carousel-next>
+          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+            <path d="M9.5 6.5L15 12l-5.5 5.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span class="visually-hidden" data-i18n="cinema.next">Next video</span>
+        </button>
+      </div>
+
+      <div class="mission-cinema__dots">
+        <button type="button" class="is-active" data-carousel-dot>
+          <span class="visually-hidden" data-i18n="cinema.dot1">Go to video 1</span>
+        </button>
+        <button type="button" data-carousel-dot>
+          <span class="visually-hidden" data-i18n="cinema.dot2">Go to video 2</span>
+        </button>
+        <button type="button" data-carousel-dot>
+          <span class="visually-hidden" data-i18n="cinema.dot3">Go to video 3</span>
+        </button>
+      </div>
+
+      <div class="mission-cinema__manifest">
+        <h3 class="mission-cinema__manifest-title" data-i18n="cinema.manifest.title">The Light We Guard</h3>
+        <p class="mission-cinema__manifest-text" data-i18n="cinema.manifest.text">To love means opening your heart to the world and letting it resonate within you. To dream means seeing beyond the horizon and daring to create the impossible. Courage is born the moment you choose to move forward, even when the path is hidden in darkness. And believing in yourself is the light that never fades, as long as you guard it within. We are building a space where love becomes movement, dreams become foundation, and faith becomes the key to the future. The world is waiting for those who dare to be themselves and live life to its fullest. Are you with us?</p>
       </div>
     </div>
 
-
   </section>
-
   <!-- 5) Контент-двигатель — «Как мемы двигают капитализацию» -->
   <section id="engine" class="reveal">
     <div class="container">

--- a/css/styles.css
+++ b/css/styles.css
@@ -61,6 +61,7 @@ body.mission-page main::after{
 }
 
 a{color:inherit;text-decoration:none}
+.visually-hidden{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important}
 .container{width:min(1200px, 92%);margin-inline:auto;position:relative}
 /* Header-specific container spacing: fixed-but-adaptive side padding */
 header .container{width:100%;max-width:100%;margin-inline:0;padding-inline:clamp(12px,3.5vw,24px)}
@@ -2596,6 +2597,291 @@ body.mission-page #fraternity{
 
 body.mission-page #memlib{
   background:radial-gradient(120% 140% at 50% 0%, rgba(123,92,255,0.18) 0%, rgba(22,15,56,0.52) 58%, rgba(9,7,24,0.78) 100%);
+}
+
+body.mission-page .mission-cinema{
+  background:
+    radial-gradient(1200px 680px at 14% -10%, rgba(240,204,132,0.28), transparent 70%),
+    radial-gradient(960px 620px at 86% 0%, rgba(123,92,255,0.22), transparent 68%),
+    linear-gradient(160deg, rgba(16,10,28,0.92), rgba(8,6,18,0.92));
+  color:var(--mission-ink);
+  font-family:'EB Garamond',serif;
+  position:relative;
+  overflow:hidden;
+}
+
+.mission-cinema::before{
+  content:"";
+  position:absolute;
+  inset:8% 12% -12% 12%;
+  border:1px solid rgba(240,204,132,0.25);
+  border-radius:48px;
+  pointer-events:none;
+  opacity:.45;
+}
+
+.mission-cinema__heading{
+  position:relative;
+  z-index:1;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:16px;
+  text-align:center;
+  margin-bottom:clamp(36px,6vw,60px);
+}
+
+.mission-cinema__chip{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 20px;
+  border-radius:999px;
+  border:1px solid rgba(240,204,132,0.42);
+  background:linear-gradient(135deg, rgba(240,204,132,0.25), rgba(123,92,255,0.18));
+  letter-spacing:.28em;
+  text-transform:uppercase;
+  font-size:11px;
+  font-family:'Cinzel',serif;
+  color:rgba(248,241,223,0.85);
+}
+
+.mission-cinema__title{
+  margin:0;
+  font-family:'Cinzel',serif;
+  font-size:clamp(34px,4.2vw,58px);
+  letter-spacing:.06em;
+  text-transform:uppercase;
+  color:var(--mission-gold-bright);
+  text-shadow:0 28px 80px rgba(6,3,0,0.48);
+}
+
+.mission-cinema__subtitle{
+  margin:0;
+  max-width:640px;
+  font-size:clamp(16px,2vw,20px);
+  line-height:1.6;
+  color:rgba(248,241,223,0.78);
+}
+
+.mission-cinema__intro{
+  position:relative;
+  z-index:1;
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:clamp(18px,3vw,28px);
+  margin-bottom:clamp(40px,6vw,64px);
+}
+
+.mission-cinema__intro-card{
+  padding:clamp(22px,3.2vw,32px);
+  border-radius:26px;
+  border:1px solid rgba(240,204,132,0.28);
+  background:linear-gradient(150deg, rgba(34,20,18,0.82), rgba(18,12,30,0.88));
+  box-shadow:0 26px 68px rgba(6,4,12,0.55);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.mission-cinema__intro-title{
+  margin:0;
+  font-family:'Cinzel',serif;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  font-size:clamp(18px,2.3vw,22px);
+  color:var(--mission-gold-bright);
+}
+
+.mission-cinema__intro-text{
+  margin:0;
+  font-size:clamp(15px,1.9vw,18px);
+  line-height:1.7;
+  color:rgba(248,241,223,0.78);
+}
+
+.mission-cinema__carousel{
+  position:relative;
+  z-index:1;
+  display:flex;
+  align-items:center;
+  gap:clamp(16px,4vw,28px);
+  margin-bottom:clamp(42px,6vw,68px);
+}
+
+.mission-cinema__viewport{
+  position:relative;
+  overflow:hidden;
+  flex:1 1 auto;
+  border-radius:32px;
+  border:1px solid rgba(240,204,132,0.32);
+  background:linear-gradient(160deg, rgba(34,20,18,0.82), rgba(16,12,30,0.9));
+  box-shadow:0 32px 90px rgba(6,4,14,0.65);
+  padding:clamp(18px,2.6vw,28px);
+}
+
+.mission-cinema__track{
+  display:flex;
+  gap:clamp(18px,3vw,28px);
+  transition:transform .6s cubic-bezier(.5,0,.25,1);
+}
+
+.mission-cinema__slide{
+  min-width:100%;
+  display:grid;
+  gap:clamp(16px,2.5vw,22px);
+  opacity:.9;
+  transition:opacity .45s ease;
+}
+
+.mission-cinema__slide.is-active{opacity:1;}
+
+.mission-cinema__frame{
+  position:relative;
+  border-radius:24px;
+  overflow:hidden;
+  border:1px solid rgba(240,204,132,0.32);
+  box-shadow:0 24px 60px rgba(6,4,18,0.55);
+  background:#000;
+  aspect-ratio:16/9;
+}
+
+.mission-cinema__frame iframe{
+  width:100%;
+  height:100%;
+  border:0;
+  display:block;
+}
+
+.mission-cinema__meta{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  padding-inline:clamp(4px,1vw,12px);
+}
+
+.mission-cinema__tag{
+  align-self:flex-start;
+  display:inline-flex;
+  align-items:center;
+  padding:6px 14px;
+  border-radius:999px;
+  border:1px solid rgba(240,204,132,0.38);
+  background:rgba(240,204,132,0.12);
+  font-family:'Cinzel',serif;
+  font-size:11px;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:rgba(248,241,223,0.78);
+}
+
+.mission-cinema__slide-title{
+  margin:0;
+  font-family:'Cinzel',serif;
+  font-size:clamp(22px,2.8vw,30px);
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  color:var(--mission-gold-bright);
+}
+
+.mission-cinema__slide-text{
+  margin:0;
+  font-size:clamp(15px,2vw,18px);
+  line-height:1.7;
+  color:rgba(248,241,223,0.8);
+}
+
+.mission-cinema__nav{
+  flex:0 0 auto;
+  width:54px;
+  height:54px;
+  border-radius:50%;
+  display:grid;
+  place-items:center;
+  border:1px solid rgba(240,204,132,0.4);
+  background:linear-gradient(150deg, rgba(240,204,132,0.22), rgba(123,92,255,0.16));
+  color:var(--mission-gold-bright);
+  box-shadow:0 20px 48px rgba(6,4,14,0.55);
+  cursor:pointer;
+  transition:transform .3s ease, box-shadow .3s ease, background .3s ease;
+}
+
+.mission-cinema__nav svg{width:26px;height:26px;}
+
+.mission-cinema__nav:hover{transform:translateY(-3px);box-shadow:0 26px 60px rgba(6,4,14,0.65);background:linear-gradient(150deg, rgba(240,204,132,0.32), rgba(123,92,255,0.24));}
+.mission-cinema__nav:focus-visible{outline:2px solid rgba(248,241,223,0.8);outline-offset:4px;}
+
+.mission-cinema__dots{
+  position:relative;
+  z-index:1;
+  display:flex;
+  justify-content:center;
+  gap:12px;
+  margin-bottom:clamp(40px,6vw,64px);
+}
+
+.mission-cinema__dots button{
+  width:14px;
+  height:14px;
+  border-radius:50%;
+  border:1px solid rgba(240,204,132,0.4);
+  background:rgba(240,204,132,0.16);
+  cursor:pointer;
+  transition:transform .3s ease, background .3s ease, box-shadow .3s ease;
+  padding:0;
+}
+
+.mission-cinema__dots button.is-active{background:var(--mission-gold);box-shadow:0 0 0 4px rgba(240,204,132,0.22);transform:translateY(-2px);}
+.mission-cinema__dots button:focus-visible{outline:2px solid rgba(248,241,223,0.85);outline-offset:3px;}
+
+.mission-cinema__manifest{
+  position:relative;
+  z-index:1;
+  padding:clamp(28px,4vw,42px);
+  border-radius:34px;
+  border:1px solid rgba(240,204,132,0.32);
+  background:linear-gradient(150deg, rgba(32,18,24,0.82), rgba(12,8,24,0.9));
+  box-shadow:0 28px 80px rgba(6,4,16,0.6);
+  display:grid;
+  gap:clamp(16px,2.6vw,22px);
+}
+
+.mission-cinema__manifest-title{
+  margin:0;
+  font-family:'Cinzel',serif;
+  letter-spacing:.2em;
+  text-transform:uppercase;
+  font-size:clamp(22px,2.8vw,28px);
+  color:var(--mission-gold-bright);
+}
+
+.mission-cinema__manifest-text{
+  margin:0;
+  font-size:clamp(16px,2.1vw,19px);
+  line-height:1.8;
+  color:rgba(248,241,223,0.85);
+}
+
+@media (max-width: 960px){
+  .mission-cinema__intro{grid-template-columns:1fr;}
+  .mission-cinema__carousel{flex-direction:column;}
+  .mission-cinema__nav{order:-1;}
+  .mission-cinema__viewport{width:100%;}
+  .mission-cinema__nav{width:52px;height:52px;}
+}
+
+@media (max-width: 640px){
+  .mission-cinema::before{inset:6% 8% -8% 8%;border-radius:28px;}
+  .mission-cinema__viewport{padding:18px;border-radius:24px;}
+  .mission-cinema__frame{border-radius:18px;}
+  .mission-cinema__dots{gap:10px;}
+  .mission-cinema__manifest{padding:24px;border-radius:24px;}
+}
+
+@media (max-width: 520px){
+  .mission-cinema__nav{width:48px;height:48px;}
+  .mission-cinema__dots button{width:12px;height:12px;}
+  .mission-cinema__manifest-title{letter-spacing:.12em;}
 }
 
 body.mission-page #roadmap-about .roadmap-board{

--- a/js/script.js
+++ b/js/script.js
@@ -58,7 +58,30 @@ const translations = {
     'pharos.paragraph1': 'Маяк Фарос был не просто башней из камня, но голосом вечности, обращённым к людям. Его свет пронзал мрак, шепча морякам: «Путь есть. Даже если ты один посреди безграничного моря». Он был создан человеком, но в его сиянии чувствовалось присутствие богов — словно сама Вселенная протягивала руку тем, кто осмеливался выйти за горизонт.',
     'pharos.paragraph2': 'Для древнего мира Фарос был чудом света, воплощением веры в то, что человеческий разум и воля способны вознести огонь к небесам. Для нас он остаётся символом надежды, мужества и выбора. Свет всегда можно зажечь, даже когда вокруг тьма, и именно он способен стать ориентиром для других.',
     'pharos.paragraph3': 'Каждый человек носит в себе свой собственный Фарос — внутренний огонь, который способен не только освещать дорогу самому, но и вдохновлять тех, кто идёт рядом.',
-    'pharos.caption': 'Зажги маяк. Подними сигнал.'
+    'pharos.caption': 'Зажги маяк. Подними сигнал.',
+    'cinema.chip': 'Сигнальное кино',
+    'cinema.title': 'Хранители поднятого света',
+    'cinema.subtitle': 'Лёгкая эллинистическая карусель с основным фильмом и трендом поднятых фонариков.',
+    'cinema.intro1.title': 'Хореография сигналов',
+    'cinema.intro1.text': 'Рандомный текст-заглушка о том, как мы выстраиваем поднятые огни, собирая мудборды и раскадровки для каждого релиза.',
+    'cinema.intro2.title': 'Пульс города',
+    'cinema.intro2.text': 'Ещё одна заглушка о креативных лабораториях, которые полируют монтаж, цвет и лор перед запуском маяка.',
+    'cinema.prev': 'Предыдущее видео',
+    'cinema.next': 'Следующее видео',
+    'cinema.dot1': 'К видео 1',
+    'cinema.dot2': 'К видео 2',
+    'cinema.dot3': 'К видео 3',
+    'cinema.slide1.tag': 'Фильм проекта',
+    'cinema.slide1.title': 'Rakodi: Свет над городом',
+    'cinema.slide1.text': 'Кинематографичный основной тизер с пролётами над невидимым городом, залитым морем огней.',
+    'cinema.slide2.tag': 'Тренд маяка',
+    'cinema.slide2.title': 'Подборка поднятых фонариков',
+    'cinema.slide2.text': 'Динамичный монтаж создателей, поднимающих свет вверх — настроение, энергия и чистый мемный импульс.',
+    'cinema.slide3.tag': 'Тренд маяка',
+    'cinema.slide3.title': 'POV ритуала маяка',
+    'cinema.slide3.text': 'Иммерсивный POV ритуала с поднятым фонариком, смешанный с реакциями толпы и синтовыми свеллами.',
+    'cinema.manifest.title': 'Свет, который мы храним',
+    'cinema.manifest.text': 'Любить — значит открывать сердце миру и позволять ему звучать в тебе. Мечтать — значит видеть дальше горизонта и не бояться создавать невозможное. Смелость рождается там, где ты выбираешь идти вперёд, даже когда путь скрыт во тьме. А вера в себя — это тот свет, который никогда не гаснет, если ты сам его хранишь. Мы строим пространство, где любовь становится движением, мечты — основой, а вера — ключом к будущему. Мир ждёт тех, кто осмелится быть собой и прожить жизнь в полную силу. Ты с нами?'
   },
   en: {
     'meta.title': 'RAKODI — Mission of the Meme City',
@@ -108,7 +131,30 @@ const translations = {
     'pharos.paragraph1': 'The Lighthouse of Pharos was not merely a tower of stone, but a voice of eternity speaking to humankind. Its light pierced through the darkness, whispering to sailors: “There is a path. Even if you are alone upon the boundless sea.” Born of human hands, yet touched by the divine, its radiance felt as though the universe itself was reaching out to those daring enough to sail beyond the horizon.',
     'pharos.paragraph2': 'For the ancient world, Pharos was a wonder, a living testament that human will and intellect could lift fire to the heavens. For us, it remains a symbol of hope, courage, and choice. Light can always be kindled, even in the deepest darkness, and once lit, it becomes a beacon for others to follow.',
     'pharos.paragraph3': 'Within each of us lies our own Pharos — an inner flame, capable not only of illuminating our own journey but also of inspiring those who walk beside us.',
-    'pharos.caption': 'Light your beacon. Raise the signal.'
+    'pharos.caption': 'Light your beacon. Raise the signal.',
+    'cinema.chip': 'Signal Cinema',
+    'cinema.title': 'Keepers of the Raised Light',
+    'cinema.subtitle': 'A gentle Hellenistic carousel that holds our core film and the torchlifting trend.',
+    'cinema.intro1.title': 'Signal Choreography',
+    'cinema.intro1.text': 'Placeholder copy about how we align the raised lights, shaping moodboards and storyboards for every drop.',
+    'cinema.intro2.title': 'City Pulse Notes',
+    'cinema.intro2.text': 'Another placeholder about the creative labs that polish edits, color, and lore before the beacon goes live.',
+    'cinema.prev': 'Previous video',
+    'cinema.next': 'Next video',
+    'cinema.dot1': 'Go to video 1',
+    'cinema.dot2': 'Go to video 2',
+    'cinema.dot3': 'Go to video 3',
+    'cinema.slide1.tag': 'Project Film',
+    'cinema.slide1.title': 'Rakodi: Light Over the City',
+    'cinema.slide1.text': 'Cinematic core teaser with sweeping shots of the invisible city rising under a sea of torches.',
+    'cinema.slide2.tag': 'Beacon Trend',
+    'cinema.slide2.title': 'Torch Trend Compilation',
+    'cinema.slide2.text': 'Quick-cut reel of creators lifting the light upward — mood, energy, and pure meme momentum.',
+    'cinema.slide3.tag': 'Beacon Trend',
+    'cinema.slide3.title': 'Beacon POV Sequence',
+    'cinema.slide3.text': 'Immersive point-of-view of the raised flashlight ritual, stitched with crowd reactions and synth swells.',
+    'cinema.manifest.title': 'The Light We Guard',
+    'cinema.manifest.text': 'To love means opening your heart to the world and letting it resonate within you. To dream means seeing beyond the horizon and daring to create the impossible. Courage is born the moment you choose to move forward, even when the path is hidden in darkness. And believing in yourself is the light that never fades, as long as you guard it within. We are building a space where love becomes movement, dreams become foundation, and faith becomes the key to the future. The world is waiting for those who dare to be themselves and live life to its fullest. Are you with us?'
   }
 };
 
@@ -169,6 +215,78 @@ document.addEventListener('click', (event)=>{
   applyLanguage(currentLang === 'ru' ? 'en' : 'ru');
 });
 
+function initMissionCarousel(){
+  document.querySelectorAll('[data-carousel]').forEach(root=>{
+    const track = root.querySelector('[data-carousel-track]');
+    if(!track) return;
+    const slides = Array.from(track.querySelectorAll('[data-carousel-slide]'));
+    if(!slides.length) return;
+    const prev = root.querySelector('[data-carousel-prev]');
+    const next = root.querySelector('[data-carousel-next]');
+    const dots = Array.from(root.querySelectorAll('[data-carousel-dot]'));
+    const viewport = root.querySelector('.mission-cinema__viewport') || root;
+    let index = 0;
+    const goTo = (newIndex)=>{
+      if(!slides.length) return;
+      index = (newIndex + slides.length) % slides.length;
+      track.style.transform = `translateX(-${index * 100}%)`;
+      slides.forEach((slide, idx)=>{
+        const isActive = idx === index;
+        slide.classList.toggle('is-active', isActive);
+        slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+      dots.forEach((dot, idx)=>{
+        const isActive = idx === index;
+        dot.classList.toggle('is-active', isActive);
+        dot.setAttribute('aria-current', isActive ? 'true' : 'false');
+      });
+    };
+    prev?.addEventListener('click', ()=>goTo(index - 1));
+    next?.addEventListener('click', ()=>goTo(index + 1));
+    dots.forEach((dot, dotIndex)=>{
+      dot.addEventListener('click', ()=>goTo(dotIndex));
+    });
+    root.addEventListener('keydown', event=>{
+      if(event.key === 'ArrowLeft'){
+        event.preventDefault();
+        goTo(index - 1);
+      }else if(event.key === 'ArrowRight'){
+        event.preventDefault();
+        goTo(index + 1);
+      }
+    });
+    let pointerActive = false;
+    let startX = 0;
+    let deltaX = 0;
+    const start = event=>{
+      pointerActive = true;
+      const point = event.touches ? event.touches[0] : event;
+      startX = point?.clientX ?? 0;
+      deltaX = 0;
+    };
+    const move = event=>{
+      if(!pointerActive) return;
+      const point = event.touches ? event.touches[0] : event;
+      const currentX = point?.clientX ?? startX;
+      deltaX = currentX - startX;
+    };
+    const end = ()=>{
+      if(!pointerActive) return;
+      pointerActive = false;
+      if(Math.abs(deltaX) > 60){
+        goTo(deltaX > 0 ? index - 1 : index + 1);
+      }
+    };
+    viewport.addEventListener('mousedown', start);
+    viewport.addEventListener('touchstart', start, {passive:true});
+    window.addEventListener('mousemove', move);
+    window.addEventListener('touchmove', move, {passive:true});
+    window.addEventListener('mouseup', end);
+    window.addEventListener('touchend', end);
+    goTo(0);
+  });
+}
+
 // Preloader (simple fade-out)
 window.addEventListener('load', ()=>{
   const pre = document.getElementById('preloader');
@@ -206,6 +324,8 @@ window.addEventListener('load', ()=>{
       });
     });
   }catch(e){ /* no-op */ }
+
+  initMissionCarousel();
 });
 
 // Reveal on scroll


### PR DESCRIPTION
## Summary
- replace the previous ecosystem diagram with a cinematic "Signal Cinema" carousel on the mission page, including placeholders for two trend clips and the core project film
- add Baldur's Gate–inspired styling for the carousel, intro cards, navigation, and manifesto block to match the requested aesthetic
- expand the translation set and ship a lightweight JS controller to handle carousel navigation, keyboard focus, and touch dragging

## Testing
- Manual QA: loaded `about.html` in the browser to verify the new carousel layout

------
https://chatgpt.com/codex/tasks/task_e_68da52bafb80832aa9d34635f8a7a1b6