### PR TITLE
Align mission cinema carousel styling with Pharos section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2714,10 +2714,10 @@ body.mission-page .mission-cinema{
   overflow:hidden;
   flex:1 1 auto;
   border-radius:32px;
-  border:1px solid rgba(240,204,132,0.32);
-  background:linear-gradient(160deg, rgba(34,20,18,0.82), rgba(16,12,30,0.9));
-  box-shadow:0 32px 90px rgba(6,4,14,0.65);
-  padding:clamp(18px,2.6vw,28px);
+  border:1px solid rgba(204,164,104,0.65);
+  background:rgba(5,4,10,0.88);
+  box-shadow:0 26px 60px rgba(8,4,16,0.6);
+  padding:clamp(20px,2.8vw,32px);
 }
 
 .mission-cinema__track{
@@ -2730,6 +2730,9 @@ body.mission-page .mission-cinema{
   min-width:100%;
   display:grid;
   gap:clamp(16px,2.5vw,22px);
+  padding:0 clamp(18px,4vw,36px);
+  box-sizing:border-box;
+  justify-items:center;
   opacity:.9;
   transition:opacity .45s ease;
 }
@@ -2740,10 +2743,13 @@ body.mission-page .mission-cinema{
   position:relative;
   border-radius:24px;
   overflow:hidden;
-  border:1px solid rgba(240,204,132,0.32);
-  box-shadow:0 24px 60px rgba(6,4,18,0.55);
-  background:#000;
+  border:1px solid rgba(204,164,104,0.65);
+  box-shadow:0 26px 60px rgba(8,4,16,0.6);
+  background:rgba(5,4,10,0.88);
   aspect-ratio:16/9;
+  width:100%;
+  max-width:860px;
+  margin:0 auto;
 }
 
 .mission-cinema__frame iframe{
@@ -2758,6 +2764,8 @@ body.mission-page .mission-cinema{
   flex-direction:column;
   gap:10px;
   padding-inline:clamp(4px,1vw,12px);
+  max-width:720px;
+  width:100%;
 }
 
 .mission-cinema__tag{
@@ -2798,17 +2806,17 @@ body.mission-page .mission-cinema{
   border-radius:50%;
   display:grid;
   place-items:center;
-  border:1px solid rgba(240,204,132,0.4);
-  background:linear-gradient(150deg, rgba(240,204,132,0.22), rgba(123,92,255,0.16));
+  border:1px solid rgba(204,164,104,0.65);
+  background:rgba(5,4,10,0.88);
   color:var(--mission-gold-bright);
-  box-shadow:0 20px 48px rgba(6,4,14,0.55);
+  box-shadow:0 26px 60px rgba(8,4,16,0.6);
   cursor:pointer;
   transition:transform .3s ease, box-shadow .3s ease, background .3s ease;
 }
 
 .mission-cinema__nav svg{width:26px;height:26px;}
 
-.mission-cinema__nav:hover{transform:translateY(-3px);box-shadow:0 26px 60px rgba(6,4,14,0.65);background:linear-gradient(150deg, rgba(240,204,132,0.32), rgba(123,92,255,0.24));}
+.mission-cinema__nav:hover{transform:translateY(-3px);box-shadow:0 34px 72px rgba(8,4,16,0.65);background:rgba(16,10,22,0.92);}
 .mission-cinema__nav:focus-visible{outline:2px solid rgba(248,241,223,0.8);outline-offset:4px;}
 
 .mission-cinema__dots{
@@ -2824,8 +2832,9 @@ body.mission-page .mission-cinema{
   width:14px;
   height:14px;
   border-radius:50%;
-  border:1px solid rgba(240,204,132,0.4);
-  background:rgba(240,204,132,0.16);
+  border:1px solid rgba(204,164,104,0.65);
+  background:rgba(5,4,10,0.88);
+  box-shadow:0 16px 36px rgba(8,4,16,0.45);
   cursor:pointer;
   transition:transform .3s ease, background .3s ease, box-shadow .3s ease;
   padding:0;
@@ -2839,9 +2848,9 @@ body.mission-page .mission-cinema{
   z-index:1;
   padding:clamp(28px,4vw,42px);
   border-radius:34px;
-  border:1px solid rgba(240,204,132,0.32);
-  background:linear-gradient(150deg, rgba(32,18,24,0.82), rgba(12,8,24,0.9));
-  box-shadow:0 28px 80px rgba(6,4,16,0.6);
+  border:1px solid rgba(204,164,104,0.65);
+  background:rgba(5,4,10,0.88);
+  box-shadow:0 26px 60px rgba(8,4,16,0.6);
   display:grid;
   gap:clamp(16px,2.6vw,22px);
 }
@@ -2868,12 +2877,15 @@ body.mission-page .mission-cinema{
   .mission-cinema__nav{order:-1;}
   .mission-cinema__viewport{width:100%;}
   .mission-cinema__nav{width:52px;height:52px;}
+  .mission-cinema__slide{padding:0 clamp(16px,6vw,26px);}
 }
 
 @media (max-width: 640px){
   .mission-cinema::before{inset:6% 8% -8% 8%;border-radius:28px;}
   .mission-cinema__viewport{padding:18px;border-radius:24px;}
+  .mission-cinema__slide{padding:0 clamp(12px,8vw,20px);}
   .mission-cinema__frame{border-radius:18px;}
+  .mission-cinema__meta{text-align:center;align-items:center;}
   .mission-cinema__dots{gap:10px;}
   .mission-cinema__manifest{padding:24px;border-radius:24px;}
 }


### PR DESCRIPTION
## Summary
- restyle the mission cinema viewport, navigation, dots, and manifest to reuse the darker Pharos panel background treatment
- add slide padding and centered frame constraints so each video sits in the middle without showing neighboring clips
- adjust responsive spacing and alignment for smaller breakpoints to preserve the centered layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5ba9d23c832abe2ded72c87e2299