### PR TITLE
Create Pharos finale call-to-action section

### DIFF
--- a/about.html
+++ b/about.html
@@ -167,104 +167,29 @@
     </div>
 
   </section>
-  <!-- 5) Контент-двигатель — «Как мемы двигают капитализацию» -->
-  <section id="engine" class="reveal">
-    <div class="container">
-      <div class="growth-headline">
-        <span class="growth-chip">внимание → действие</span>
-        <h2 class="section-title">Простая связка роста</h2>
-        <p class="section-sub">Пять шагов соединяют вирусные эмоции, понятный онбординг и доказательство ценности. Каждая стадия усиливает предыдущую и приводит зрителя в устойчивое ядро сообщества.</p>
+  <!-- 5) Финальный призыв — «Фарос зажжён» -->
+  <section id="pharos-finale" class="reveal mission-finale">
+    <div class="mission-finale__backdrop" aria-hidden="true"></div>
+    <div class="mission-finale__glow mission-finale__glow--left" aria-hidden="true"></div>
+    <div class="mission-finale__glow mission-finale__glow--right" aria-hidden="true"></div>
+    <div class="container mission-finale__inner">
+      <span class="mission-finale__chip" data-i18n="finale.chip">Trend I · Beacon Ignited</span>
+      <h2 class="mission-finale__title" data-i18n="finale.title">Pharos is Lit!</h2>
+      <div class="mission-finale__divider" aria-hidden="true"></div>
+      <div class="mission-finale__body">
+        <p data-i18n="finale.paragraph1">We have lit our own Pharos. Long ago, on the island of Pharos, the greatest lighthouse of the ancient world shone — a wonder of light whose fire guided sailors through darkness and storms. Its radiance spoke to every traveler: “You are not alone. The path exists.” Today, we carry that tradition forward. RAKODI lights its own Pharos — not of stone and fire, but of ideas, courage, and faith in humanity. Faith in you. This is a light strong enough to pierce through doubt and open the road to the future.</p>
+        <p data-i18n="finale.paragraph2">We believe: just as the Lighthouse of Pharos once stood as a symbol of hope and greatness, so too will our Pharos become the symbol of a new path. May its brilliance guide those who seek their own light, and be the sign that together we can transform a night of madness and fear into a dawn of reason and hope.</p>
       </div>
-      <div class="growth-layout">
-        <div class="growth-diagram">
-          <div class="growth-orbit"></div>
-          <div class="growth-core">
-            <span class="core-top">Импульс</span>
-            <strong>Внимание × Лояльность</strong>
-            <span class="core-bottom">Комьюнити</span>
-          </div>
-          <div class="growth-node step-1">
-            <div class="growth-bubble">I</div>
-            <div class="growth-node-body">
-              <h3>Тизер</h3>
-              <p class="muted">эмоция и крючок из видео</p>
-            </div>
-          </div>
-          <div class="growth-node step-2">
-            <div class="growth-bubble">II</div>
-            <div class="growth-node-body">
-              <h3>Просмотры</h3>
-              <p class="muted">охват и обсуждение в соцсетях</p>
-            </div>
-          </div>
-          <div class="growth-node step-3">
-            <div class="growth-bubble">III</div>
-            <div class="growth-node-body">
-              <h3>Сайт</h3>
-              <p class="muted">понимание идеи, конверсия в Братство и токен</p>
-            </div>
-          </div>
-          <div class="growth-node step-4">
-            <div class="growth-bubble">IV</div>
-            <div class="growth-node-body">
-              <h3>Комьюнити</h3>
-              <p class="muted">квесты, мем‑библиотека, UGC</p>
-            </div>
-          </div>
-          <div class="growth-node step-5">
-            <div class="growth-bubble">V</div>
-            <div class="growth-node-body">
-              <h3>Сигналы рынка</h3>
-              <p class="muted">рост узнаваемости, путь к DEX</p>
-            </div>
-          </div>
-        </div>
-        <div class="growth-info">
-          <div class="growth-info-card card">
-            <h3>Как работает связка</h3>
-            <p class="muted">Связываем эмоцию, структуру и социальное доказательство. Поток проходит через медиа, платформу и живое сообщество, чтобы закрепить ценность.</p>
-            <ul class="growth-list">
-              <li>
-                <span class="growth-dot">I–II</span>
-                <div>
-                  <strong>Импульс медиа</strong>
-                  <p class="muted">Тизеры и просмотры поднимают эмоциональную волну и обрастают обсуждениями.</p>
-                </div>
-              </li>
-              <li>
-                <span class="growth-dot">III</span>
-                <div>
-                  <strong>Онбординг</strong>
-                  <p class="muted">Сайт объясняет идею, приводит в Братство и даёт понятный первый шаг.</p>
-                </div>
-              </li>
-              <li>
-                <span class="growth-dot">IV–V</span>
-                <div>
-                  <strong>Сообщество и доверие</strong>
-                  <p class="muted">Комьюнити удерживает внимание квестами, а сигналы рынка подтверждают рост.</p>
-                </div>
-              </li>
-            </ul>
-            <div class="growth-progress" style="--growth-progress:0.62">
-              <div class="growth-progress-track">
-                <div class="growth-progress-fill"></div>
-              </div>
-              <div class="growth-progress-labels">
-                <span>I</span>
-                <span>II</span>
-                <span>III</span>
-                <span>IV</span>
-                <span>V</span>
-              </div>
-              <p class="growth-progress-caption small">Сейчас раскачиваем первые этапы, чтобы масштабировать эффект и перевести его в долгосрочную ценность сообщества.</p>
-            </div>
-          </div>
-        </div>
+      <div class="mission-finale__actions">
+        <a class="mission-finale__cta btn btn--gold" href="https://t.me/rakodi" target="_blank" rel="noopener noreferrer" data-i18n="finale.cta.telegram">Join the Telegram Signal</a>
+        <a class="mission-finale__cta btn btn--outline" href="brotherhood.html" data-i18n="finale.cta.brotherhood">Enter the Brotherhood</a>
       </div>
-      <p class="growth-note small">Мы ничего не обещаем про цену. Мы строим систему, где внимание превращается в действие, а действие — в устойчивое сообщество.</p>
+      <ul class="mission-finale__hashtags">
+        <li><span data-i18n="finale.hashtag1">#PharosIgnited</span></li>
+        <li><span data-i18n="finale.hashtag2">#RakodiBeacon</span></li>
+        <li><span data-i18n="finale.hashtag3">#LightTheOrder</span></li>
+      </ul>
     </div>
-
   </section>
 
   <!-- 6) Мем-библиотека — «Архив, который смеётся» -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -470,293 +470,153 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .alexandria-media__caption{letter-spacing:.1em;}
 }
 
-/* Growth engine — инфографика связки роста */
-#engine{overflow:hidden}
-#engine::before{
-  content:"";
-  position:absolute;
-  inset:-45% -40% auto 50%;
-  width:520px;
-  height:520px;
-  background:radial-gradient(circle at 50% 50%, rgba(123,92,255,0.22), transparent 70%);
-  opacity:.55;
-  transform:translateX(-50%);
-  pointer-events:none;
-  filter:blur(0.6px);
-}
-#engine .container{position:relative;z-index:1}
-
-.growth-headline{max-width:760px;margin:0 auto 60px;text-align:center;display:grid;gap:16px}
-.growth-chip{
-  display:inline-flex;
-  align-items:center;
-  gap:8px;
-  margin-inline:auto;
-  padding:6px 16px;
-  border-radius:999px;
-  border:1px solid rgba(255,255,255,0.16);
-  background:rgba(255,255,255,0.05);
-  text-transform:uppercase;
-  letter-spacing:.24em;
-  font-size:12px;
-  color:#fff9;
-}
-.growth-chip::before{content:"◈";color:var(--accent);font-size:14px;opacity:.86}
-
-.growth-layout{display:grid;gap:48px;grid-template-columns:minmax(0,1.1fr) minmax(0,0.9fr);align-items:stretch}
-
-.growth-diagram{
+/* Pharos finale — завершающий призыв */
+.mission-finale{
   position:relative;
-  border-radius:32px;
-  padding:72px 64px;
-  background:linear-gradient(180deg, rgba(18,20,36,0.9), rgba(11,11,22,0.68));
-  border:1px solid rgba(255,255,255,0.12);
-  box-shadow:0 26px 60px rgba(8,4,22,0.55);
-  min-height:520px;
+  padding:clamp(140px,36vw,220px) 0 clamp(120px,30vw,200px);
+  text-align:center;
+  color:var(--mission-ink);
   overflow:hidden;
   isolation:isolate;
 }
-.growth-diagram::before{
-  content:"";
+.mission-finale__backdrop{
   position:absolute;
-  inset:10% 14%;
-  border-radius:50%;
-  background:radial-gradient(circle at 50% 50%, rgba(255,255,255,0.04), transparent 62%);
-  border:1px solid rgba(255,255,255,0.06);
-  opacity:.8;
-  pointer-events:none;
+  inset:0;
+  background:
+    radial-gradient(circle at 20% 10%,rgba(240,204,132,0.28),transparent 65%),
+    radial-gradient(circle at 80% 18%,rgba(255,134,120,0.2),transparent 60%),
+    linear-gradient(165deg,rgba(18,10,20,0.96),rgba(8,4,14,0.94));
+  filter:saturate(1.05);
+  opacity:0.96;
+  z-index:-3;
 }
-
-.growth-orbit{
+.mission-finale__glow{
   position:absolute;
-  inset:18%;
-  border-radius:50%;
-  border:1px dashed rgba(255,255,255,0.12);
-  background:conic-gradient(from 90deg, rgba(255,46,106,0.28), rgba(123,92,255,0.04) 40%, rgba(255,46,106,0.28) 80%, rgba(123,92,255,0.08));
-  opacity:.55;
-  filter:blur(0.4px);
-  pointer-events:none;
+  width:46vw;
+  max-width:620px;
+  aspect-ratio:1;
+  background:radial-gradient(circle,rgba(255,214,169,0.35),rgba(255,214,169,0));
+  filter:blur(60px);
+  opacity:0.6;
+  z-index:-2;
 }
-
-.growth-core{
-  position:absolute;
-  top:50%;
-  left:50%;
-  transform:translate(-50%,-50%);
-  width:230px;
-  aspect-ratio:1/1;
-  border-radius:50%;
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  justify-content:center;
-  gap:6px;
-  text-align:center;
-  text-transform:uppercase;
-  letter-spacing:.22em;
-  font-size:12px;
-  color:#f4f2ff;
-  background:radial-gradient(circle at 34% 32%, rgba(255,46,106,0.32), rgba(15,16,30,0.88));
-  border:1px solid rgba(255,255,255,0.18);
-  box-shadow:0 30px 60px rgba(7,4,26,0.52);
-}
-.growth-core::before{
-  content:"";
-  position:absolute;
-  inset:-20%;
-  border-radius:50%;
-  background:linear-gradient(135deg, rgba(255,46,106,0.42), rgba(123,92,255,0.4));
-  opacity:.35;
-  filter:blur(22px);
-  z-index:-1;
-}
-.growth-core strong{font-size:18px;letter-spacing:.18em;line-height:1.4}
-.growth-core .core-top,.growth-core .core-bottom{font-size:11px;opacity:.75;letter-spacing:.28em}
-
-.growth-node{
-  position:absolute;
-  display:flex;
-  align-items:flex-start;
-  gap:14px;
-  width:216px;
-  padding:16px 18px;
-  border-radius:22px;
-  background:rgba(10,12,26,0.78);
-  border:1px solid rgba(255,255,255,0.14);
-  box-shadow:0 22px 48px rgba(6,3,18,0.5);
-  backdrop-filter:blur(12px);
-  z-index:2;
-}
-.growth-node h3{margin:0;font-size:18px;letter-spacing:.02em}
-.growth-node p{margin:6px 0 0;font-size:14px;line-height:1.5}
-.growth-node-body{display:grid;gap:6px}
-
-.growth-bubble{
-  width:46px;
-  height:46px;
-  border-radius:14px;
+.mission-finale__glow--left{top:-18%;left:-10%;}
+.mission-finale__glow--right{bottom:-24%;right:-12%;}
+.mission-finale__inner{
+  position:relative;
   display:grid;
-  place-items:center;
-  font-weight:700;
-  letter-spacing:.08em;
-  color:#fff;
-  background:linear-gradient(140deg,var(--accent),var(--accent-2));
-  box-shadow:0 12px 24px rgba(255,46,106,0.35);
-  flex-shrink:0;
+  gap:clamp(22px,4vw,36px);
+  justify-items:center;
+  max-width:860px;
+  margin:0 auto;
+  padding:0 clamp(18px,4vw,36px);
 }
-
-.growth-node.step-1{top:18px;left:50%;transform:translate(-50%,0);flex-direction:column;align-items:center;text-align:center;width:220px}
-.growth-node.step-1 .growth-bubble{margin-bottom:10px}
-.growth-node.step-1::after{
-  content:"";
-  position:absolute;
-  top:calc(100% + 4px);
-  left:50%;
-  width:1px;
-  height:76px;
-  background:linear-gradient(180deg, rgba(255,255,255,0.5), rgba(123,92,255,0));
-  transform:translateX(-50%);
-  opacity:.7;
-}
-
-.growth-node.step-2{top:122px;right:22px}
-.growth-node.step-2::after{
-  content:"";
-  position:absolute;
-  top:50%;
-  right:calc(100% - 24px);
-  width:128px;
-  height:1px;
-  background:linear-gradient(270deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
-  transform-origin:right center;
-  transform:rotate(18deg);
-  opacity:.7;
-}
-
-.growth-node.step-3{bottom:118px;right:26px}
-.growth-node.step-3::after{
-  content:"";
-  position:absolute;
-  top:50%;
-  right:calc(100% - 22px);
-  width:134px;
-  height:1px;
-  background:linear-gradient(270deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
-  transform-origin:right center;
-  transform:rotate(-16deg);
-  opacity:.7;
-}
-
-.growth-node.step-4{bottom:40px;left:28px}
-.growth-node.step-4::after{
-  content:"";
-  position:absolute;
-  top:50%;
-  left:calc(100% - 24px);
-  width:136px;
-  height:1px;
-  background:linear-gradient(90deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
-  transform-origin:left center;
-  transform:rotate(-12deg);
-  opacity:.7;
-}
-
-.growth-node.step-5{top:152px;left:24px}
-.growth-node.step-5::after{
-  content:"";
-  position:absolute;
-  top:50%;
-  left:calc(100% - 24px);
-  width:132px;
-  height:1px;
-  background:linear-gradient(90deg, rgba(255,255,255,0.55), rgba(123,92,255,0));
-  transform-origin:left center;
-  transform:rotate(20deg);
-  opacity:.7;
-}
-
-.growth-info{display:flex;flex-direction:column;gap:24px}
-.growth-info-card{display:grid;gap:24px}
-.growth-info-card h3{margin:0;font-size:26px}
-
-.growth-list{list-style:none;margin:0;padding:0;display:grid;gap:18px}
-.growth-list li{display:flex;gap:14px;align-items:flex-start}
-.growth-list li div{display:grid;gap:6px}
-.growth-list li p{margin:0;line-height:1.55}
-.growth-list li strong{font-size:18px;letter-spacing:.02em}
-
-.growth-dot{
+.mission-finale__chip{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  min-width:64px;
-  padding:8px 14px;
-  border-radius:14px;
-  border:1px solid rgba(255,255,255,0.22);
-  background:linear-gradient(140deg, rgba(255,255,255,0.05), rgba(123,92,255,0.12));
-  box-shadow:inset 0 0 18px rgba(123,92,255,0.25);
-  font-weight:700;
-  letter-spacing:.1em;
+  gap:10px;
+  padding:10px 24px;
+  border-radius:999px;
+  border:1px solid rgba(240,204,132,0.38);
+  background:linear-gradient(140deg,rgba(240,204,132,0.14),rgba(240,204,132,0.04));
+  letter-spacing:.32em;
+  text-transform:uppercase;
+  font-size:11px;
+  font-family:'Cinzel',serif;
+  color:rgba(245,224,188,0.9);
+  text-shadow:0 0 14px rgba(240,204,132,0.35);
+}
+.mission-finale__chip::before{
+  content:"✶";
+  font-size:14px;
+  color:var(--mission-gold-bright);
+}
+.mission-finale__title{
+  margin:0;
+  font-family:'Cinzel',serif;
+  font-size:clamp(44px,6vw,68px);
+  letter-spacing:.18em;
+  text-transform:uppercase;
+  color:var(--mission-gold-bright);
+  text-shadow:0 24px 80px rgba(12,4,0,0.8),0 0 18px rgba(240,204,132,0.65);
+}
+.mission-finale__divider{
+  width:min(320px,60%);
+  height:2px;
+  border-radius:999px;
+  background:linear-gradient(90deg,rgba(240,204,132,0),rgba(240,204,132,0.7),rgba(240,204,132,0));
+}
+.mission-finale__body{
+  display:grid;
+  gap:clamp(16px,3vw,26px);
+  font-family:'EB Garamond',serif;
+  font-size:clamp(18px,2.1vw,24px);
+  line-height:1.75;
+  color:rgba(249,239,220,0.94);
+}
+.mission-finale__actions{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:16px;
+}
+.mission-finale__cta{
+  min-width:220px;
+  font-family:'Cinzel',serif;
+  letter-spacing:.16em;
+}
+.mission-finale__cta.btn--outline{
+  border-color:rgba(240,204,132,0.42);
+  color:var(--mission-gold-bright);
+  background:linear-gradient(120deg,rgba(240,204,132,0.08),rgba(240,204,132,0.02));
+}
+.mission-finale__cta.btn--outline:hover{
+  color:#1b1208;
+}
+.mission-finale__hashtags{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:14px;
+  font-family:'Cinzel',serif;
   font-size:13px;
-  color:#f2f0ff;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:rgba(240,204,132,0.82);
 }
-
-.growth-progress{display:grid;gap:12px;padding:4px;border-radius:20px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.08)}
-.growth-progress-track{position:relative;height:12px;border-radius:999px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);overflow:hidden}
-.growth-progress-fill{position:absolute;inset:0;width:calc(var(--growth-progress,0.5) * 100%);background:linear-gradient(90deg,var(--accent),var(--accent-2));box-shadow:0 0 16px rgba(123,92,255,0.45)}
-.growth-progress-labels{display:flex;justify-content:space-between;gap:8px;font-size:12px;text-transform:uppercase;letter-spacing:.18em;color:#fff9}
-.growth-progress-labels span{display:grid;place-items:center;min-width:38px;height:28px;border-radius:999px;border:1px solid rgba(255,255,255,0.16);background:rgba(255,255,255,0.04);font-weight:600}
-.growth-progress-caption{margin:0;color:rgba(236,231,255,0.65)}
-
-.growth-note{margin:40px auto 0;text-align:center;max-width:720px;color:rgba(236,231,255,0.7)}
-
-@media (max-width:1080px){
-  .growth-layout{grid-template-columns:1fr}
-  .growth-diagram{margin-inline:auto}
+.mission-finale__hashtags li{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  padding:8px 14px;
+  border-radius:999px;
+  border:1px solid rgba(240,204,132,0.26);
+  background:rgba(240,204,132,0.05);
 }
-
-@media (max-width:860px){
-  .growth-diagram{padding:56px 44px;min-height:480px}
-  .growth-node{width:200px}
-  .growth-node.step-2{top:110px;right:16px}
-  .growth-node.step-3{bottom:110px;right:18px}
-  .growth-node.step-4{bottom:38px;left:18px}
-  .growth-node.step-5{top:142px;left:16px}
+.mission-finale__hashtags span{
+  letter-spacing:.1em;
+  text-transform:none;
+  color:inherit;
+  font-family:inherit;
 }
-
-@media (max-width:760px){
-  .growth-layout{gap:36px}
-  .growth-diagram{padding:36px 26px;min-height:0;display:grid;gap:18px}
-  .growth-diagram::before,.growth-orbit{display:none}
-  .growth-node{
-    position:relative;
-    width:100%;
-    left:auto;
-    right:auto;
-    top:auto;
-    bottom:auto;
-    transform:none !important;
-    background:rgba(16,17,36,0.88);
-  }
-  .growth-node::after{display:none}
-  .growth-node.step-1{flex-direction:row;align-items:flex-start;text-align:left}
-  .growth-node.step-1 .growth-bubble{margin-bottom:0}
-  .growth-core{
-    position:relative;
-    transform:none;
-    margin:0 auto 12px;
-    width:min(240px,70vw);
-  }
-  .growth-info-card{padding:6px 0}
-  .growth-dot{min-width:56px}
+@media (max-width:720px){
+  .mission-finale{padding:120px 0 140px;}
+  .mission-finale__title{letter-spacing:.12em;}
+  .mission-finale__chip{letter-spacing:.22em;}
+  .mission-finale__hashtags{gap:10px;font-size:12px;}
+  .mission-finale__hashtags li{padding:6px 12px;}
 }
-
 @media (max-width:520px){
-  .growth-diagram{padding:28px 20px}
-  .growth-core{width:min(220px,68vw)}
-  .growth-dot{min-width:48px;font-size:12px;letter-spacing:.08em}
-  .growth-progress-labels span{min-width:34px;height:26px;font-size:11px}
+  .mission-finale__cta{min-width:0;width:100%;}
+  .mission-finale__divider{width:70%;}
+  .mission-finale__hashtags{flex-direction:column;gap:8px;}
+  .mission-finale__hashtags li{justify-content:center;}
 }
+
 .legend-section{
   position:relative;
   padding:150px 0;
@@ -3488,7 +3348,6 @@ body.mission-page .faq-section{
   .memlib-stat__meta{flex-direction:column;align-items:flex-start}
 }
 #ecosystem > .container + .container{margin:10px 0}
-#engine > .container + .container{margin:10px 0}
 
 .partners-marquee{
   position:relative;

--- a/js/script.js
+++ b/js/script.js
@@ -73,7 +73,16 @@ const translations = {
     'cinema.slide2.title': 'Подборка поднятых фонариков',
     'cinema.slide2.text': 'Динамичный монтаж создателей, поднимающих свет вверх — настроение, энергия и чистый мемный импульс.',
     'cinema.manifest.title': 'Свет, который мы храним',
-    'cinema.manifest.text': 'Любить — значит открывать сердце миру и позволять ему звучать в тебе. Мечтать — значит видеть дальше горизонта и не бояться создавать невозможное. Смелость рождается там, где ты выбираешь идти вперёд, даже когда путь скрыт во тьме. А вера в себя — это тот свет, который никогда не гаснет, если ты сам его хранишь. Мы строим пространство, где любовь становится движением, мечты — основой, а вера — ключом к будущему. Мир ждёт тех, кто осмелится быть собой и прожить жизнь в полную силу. Ты с нами?'
+    'cinema.manifest.text': 'Любить — значит открывать сердце миру и позволять ему звучать в тебе. Мечтать — значит видеть дальше горизонта и не бояться создавать невозможное. Смелость рождается там, где ты выбираешь идти вперёд, даже когда путь скрыт во тьме. А вера в себя — это тот свет, который никогда не гаснет, если ты сам его хранишь. Мы строим пространство, где любовь становится движением, мечты — основой, а вера — ключом к будущему. Мир ждёт тех, кто осмелится быть собой и прожить жизнь в полную силу. Ты с нами?',
+    'finale.chip': 'Тренд I · Огонь маяка',
+    'finale.title': 'Фарос зажжён!',
+    'finale.paragraph1': 'Мы зажгли свой Фарос. Когда-то на острове Фарос горел величайший маяк древнего мира — чудо света, огонь которого освещал морякам путь через тьму и штормы. Его свет говорил каждому: «Ты не один. Путь существует». Сегодня мы продолжаем эту традицию. RAKODI зажигает свой собственный Фарос — не из камня и огня, а из идей, смелости и веры в человека. Веры в тебя. Это свет, который способен пробить тьму сомнений и открыть дорогу в будущее.',
+    'finale.paragraph2': 'Мы верим: как маяк Фарос однажды стал символом надежды и величия, так и наш Фарос будет символом нового пути. Пусть его сияние станет ориентиром для тех, кто ищет свой свет, и знаком того, что вместе мы способны превратить ночь безумия и страха в рассвет разума и надежды.',
+    'finale.cta.telegram': 'Сигнал в Telegram',
+    'finale.cta.brotherhood': 'Войти в Братство',
+    'finale.hashtag1': '#ФаросЗажжён',
+    'finale.hashtag2': '#RakodiBeacon',
+    'finale.hashtag3': '#ЗажгиОрден'
   },
   en: {
     'meta.title': 'RAKODI — Mission of the Meme City',
@@ -138,7 +147,16 @@ const translations = {
     'cinema.slide2.title': 'Torch Trend Compilation',
     'cinema.slide2.text': 'Quick-cut reel of creators lifting the light upward — mood, energy, and pure meme momentum.',
     'cinema.manifest.title': 'The Light We Guard',
-    'cinema.manifest.text': 'To love means opening your heart to the world and letting it resonate within you. To dream means seeing beyond the horizon and daring to create the impossible. Courage is born the moment you choose to move forward, even when the path is hidden in darkness. And believing in yourself is the light that never fades, as long as you guard it within. We are building a space where love becomes movement, dreams become foundation, and faith becomes the key to the future. The world is waiting for those who dare to be themselves and live life to its fullest. Are you with us?'
+    'cinema.manifest.text': 'To love means opening your heart to the world and letting it resonate within you. To dream means seeing beyond the horizon and daring to create the impossible. Courage is born the moment you choose to move forward, even when the path is hidden in darkness. And believing in yourself is the light that never fades, as long as you guard it within. We are building a space where love becomes movement, dreams become foundation, and faith becomes the key to the future. The world is waiting for those who dare to be themselves and live life to its fullest. Are you with us?',
+    'finale.chip': 'Trend I · Beacon Ignited',
+    'finale.title': 'Pharos is Lit!',
+    'finale.paragraph1': 'We have lit our own Pharos. Long ago, on the island of Pharos, the greatest lighthouse of the ancient world shone — a wonder of light whose fire guided sailors through darkness and storms. Its radiance spoke to every traveler: “You are not alone. The path exists.” Today, we carry that tradition forward. RAKODI lights its own Pharos — not of stone and fire, but of ideas, courage, and faith in humanity. Faith in you. This is a light strong enough to pierce through doubt and open the road to the future.',
+    'finale.paragraph2': 'We believe: just as the Lighthouse of Pharos once stood as a symbol of hope and greatness, so too will our Pharos become the symbol of a new path. May its brilliance guide those who seek their own light, and be the sign that together we can transform a night of madness and fear into a dawn of reason and hope.',
+    'finale.cta.telegram': 'Join the Telegram Signal',
+    'finale.cta.brotherhood': 'Enter the Brotherhood',
+    'finale.hashtag1': '#PharosIgnited',
+    'finale.hashtag2': '#RakodiBeacon',
+    'finale.hashtag3': '#LightTheOrder'
   }
 };
 


### PR DESCRIPTION
## Summary
- Replace the mission page growth-engine block with the bilingual Pharos finale CTA featuring Telegram and Brotherhood links alongside trend hashtags.
- Introduce a Baldur's Gate-inspired visual treatment for the finale section with glows, dividers, and responsive layout adjustments.
- Extend the translation map with Russian and English strings for the finale copy and call-to-action labels.

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da68e85548832a9380abf97a558220