### PR TITLE
Adjust mission carousel width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -370,6 +370,8 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   border:1px solid rgba(240,204,132,0.32);
   box-shadow:0 46px 120px rgba(10,4,0,0.65);
   backdrop-filter:blur(14px);
+  width:min(100%, 760px);
+  margin-inline:auto;
 }
 .mission-cinema__nav{
   position:absolute;
@@ -386,8 +388,8 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   transition:transform .25s ease, box-shadow .25s ease, background .25s ease;
   transform:translateY(-50%);
 }
-.mission-cinema__nav--prev{left:calc(-1 * clamp(48px,6vw,72px));}
-.mission-cinema__nav--next{right:calc(-1 * clamp(48px,6vw,72px));}
+.mission-cinema__nav--prev{left:calc(-1 * clamp(28px,4vw,44px));}
+.mission-cinema__nav--next{right:calc(-1 * clamp(28px,4vw,44px));}
 .mission-cinema__nav svg{width:22px;height:22px;stroke:currentColor;}
 .mission-cinema__nav:hover{transform:translateY(calc(-50% - 2px));box-shadow:0 22px 46px rgba(240,204,132,0.3);background:linear-gradient(140deg,rgba(240,204,132,0.55),rgba(32,18,12,0.6));}
 .mission-cinema__nav:focus-visible{outline:3px solid rgba(240,204,132,0.65);outline-offset:4px;}
@@ -395,7 +397,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   position:relative;
   overflow:hidden;
   border-radius:30px;
-  width:min(780px,100%);
+  width:min(640px,100%);
   margin-inline:auto;
 }
 .mission-cinema__track{
@@ -505,14 +507,14 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .mission-cinema__manifest-text{margin:0;font-family:'EB Garamond',serif;font-size:clamp(18px,2.2vw,22px);line-height:1.8;color:rgba(248,241,223,0.86);}
 
 @media (max-width:1100px){
-  .mission-cinema__viewport{width:min(700px,100%);}
-  .mission-cinema__nav--prev{left:calc(-1 * clamp(40px,5vw,60px));}
-  .mission-cinema__nav--next{right:calc(-1 * clamp(40px,5vw,60px));}
+  .mission-cinema__viewport{width:min(600px,100%);}
+  .mission-cinema__nav--prev{left:calc(-1 * clamp(20px,4vw,32px));}
+  .mission-cinema__nav--next{right:calc(-1 * clamp(20px,4vw,32px));}
 
   .mission-cinema__carousel{grid-template-columns:minmax(0,1fr);}
   .mission-cinema__nav{order:-1;justify-self:center;}
   .mission-cinema__nav--next{order:1;}
-  .mission-cinema__viewport{width:100%;}
+  .mission-cinema__viewport{width:min(600px,100%);}
   .mission-cinema__slide{min-width:100%;}
 }
 
@@ -520,8 +522,8 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .mission-cinema{padding:clamp(72px,26vw,120px) 0 clamp(60px,18vw,100px);}
   .mission-cinema__carousel{padding:24px;border-radius:32px;gap:18px;}
   .mission-cinema__nav{width:52px;height:52px;}
-  .mission-cinema__nav--prev{left:-32px;}
-  .mission-cinema__nav--next{right:-32px;}
+  .mission-cinema__nav--prev{left:-24px;}
+  .mission-cinema__nav--next{right:-24px;}
   .mission-cinema__viewport{width:min(620px,100%);}
 
   .mission-cinema__frame{border-radius:24px;}


### PR DESCRIPTION
## Summary
- limit the Mission page video carousel width and center it so navigation controls stay within the viewport
- tighten navigation button offsets across breakpoints to prevent overflow on smaller screens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da751c6b9c832a85445d4b7b99e2d3