### PR TITLE
Center mission cinema video and stabilize controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -356,14 +356,11 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .mission-cinema .container{display:grid;gap:clamp(36px,5vw,52px);}
 .mission-cinema__carousel{
   position:relative;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:clamp(16px,3vw,28px);
   display:grid;
   grid-template-columns:auto minmax(0,1fr) auto;
   gap:clamp(16px,3vw,28px);
   align-items:center;
+  justify-items:center;
   padding:clamp(26px,4vw,38px);
   border-radius:42px;
   background:linear-gradient(150deg,rgba(34,20,8,0.75),rgba(16,8,10,0.92));
@@ -374,8 +371,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   margin-inline:auto;
 }
 .mission-cinema__nav{
-  position:absolute;
-  top:50%;
+  position:static;
   display:grid;
   place-items:center;
   width:58px;
@@ -385,13 +381,10 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   color:var(--mission-gold-bright);
   background:radial-gradient(circle at 50% 30%, rgba(240,204,132,0.38), rgba(32,18,12,0.52));
   cursor:pointer;
-  transition:transform .25s ease, box-shadow .25s ease, background .25s ease;
-  transform:translateY(-50%);
+  transition:box-shadow .25s ease, background .25s ease;
 }
-.mission-cinema__nav--prev{left:calc(-1 * clamp(28px,4vw,44px));}
-.mission-cinema__nav--next{right:calc(-1 * clamp(28px,4vw,44px));}
 .mission-cinema__nav svg{width:22px;height:22px;stroke:currentColor;}
-.mission-cinema__nav:hover{transform:translateY(calc(-50% - 2px));box-shadow:0 22px 46px rgba(240,204,132,0.3);background:linear-gradient(140deg,rgba(240,204,132,0.55),rgba(32,18,12,0.6));}
+.mission-cinema__nav:hover{box-shadow:0 22px 46px rgba(240,204,132,0.3);background:linear-gradient(140deg,rgba(240,204,132,0.55),rgba(32,18,12,0.6));}
 .mission-cinema__nav:focus-visible{outline:3px solid rgba(240,204,132,0.65);outline-offset:4px;}
 .mission-cinema__viewport{
   position:relative;
@@ -415,8 +408,6 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   box-sizing:border-box;
 
 }
-.mission-cinema__nav svg{width:22px;height:22px;stroke:currentColor;}
-.mission-cinema__nav:hover{transform:translateY(-2px);box-shadow:0 22px 46px rgba(240,204,132,0.3);background:linear-gradient(140deg,rgba(240,204,132,0.55),rgba(32,18,12,0.6));}
 .mission-cinema__nav:focus-visible{outline:3px solid rgba(240,204,132,0.65);outline-offset:4px;}
 .mission-cinema__viewport{
   overflow:hidden;
@@ -507,14 +498,8 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .mission-cinema__manifest-text{margin:0;font-family:'EB Garamond',serif;font-size:clamp(18px,2.2vw,22px);line-height:1.8;color:rgba(248,241,223,0.86);}
 
 @media (max-width:1100px){
-  .mission-cinema__viewport{width:min(600px,100%);}
-  .mission-cinema__nav--prev{left:calc(-1 * clamp(20px,4vw,32px));}
-  .mission-cinema__nav--next{right:calc(-1 * clamp(20px,4vw,32px));}
-
-  .mission-cinema__carousel{grid-template-columns:minmax(0,1fr);}
-  .mission-cinema__nav{order:-1;justify-self:center;}
-  .mission-cinema__nav--next{order:1;}
-  .mission-cinema__viewport{width:min(600px,100%);}
+  .mission-cinema__carousel{width:min(100%,700px);}
+  .mission-cinema__viewport{width:min(580px,100%);}
   .mission-cinema__slide{min-width:100%;}
 }
 
@@ -522,8 +507,6 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
   .mission-cinema{padding:clamp(72px,26vw,120px) 0 clamp(60px,18vw,100px);}
   .mission-cinema__carousel{padding:24px;border-radius:32px;gap:18px;}
   .mission-cinema__nav{width:52px;height:52px;}
-  .mission-cinema__nav--prev{left:-24px;}
-  .mission-cinema__nav--next{right:-24px;}
   .mission-cinema__viewport{width:min(620px,100%);}
 
   .mission-cinema__frame{border-radius:24px;}
@@ -532,8 +515,6 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 @media (max-width:520px){
   .mission-cinema__carousel{gap:14px;}
   .mission-cinema__nav{width:48px;height:48px;}
-  .mission-cinema__nav--prev{left:-24px;}
-  .mission-cinema__nav--next{right:-24px;}
 
   .mission-cinema__meta{gap:8px;}
   .mission-cinema__tag{letter-spacing:.22em;font-size:10px;padding:6px 12px;}


### PR DESCRIPTION
## Summary
- center the mission cinema carousel in its container and keep the frame aligned
- reposition navigation controls so they sit beside the video with consistent spacing and no hover movement
- adjust responsive rules to preserve the centered layout across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da776b3008832a94f1dbc09a034a60