### PR TITLE
Match mission section media height with text content

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2529,7 +2529,7 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 }
 .mission-ethos{position:relative;padding:6.5rem 0;overflow:hidden;}
 .mission-ethos::before{content:"";position:absolute;inset:0;pointer-events:none;}
-.mission-ethos__inner{position:relative;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,420px);gap:4rem;align-items:center;padding:3.5rem clamp(1.5rem,3.6vw,3.75rem);border:1px solid rgba(244,193,110,.28);border-radius:36px;background: linear-gradient(150deg, rgba(34, 18, 8, 0.92), rgba(16, 8, 6, 0.88));box-shadow:0 32px 80px rgba(8,6,16,.65);backdrop-filter:blur(14px);}
+.mission-ethos__inner{position:relative;display:grid;grid-template-columns:minmax(0,1fr) minmax(0,420px);gap:4rem;align-items:stretch;padding:3.5rem clamp(1.5rem,3.6vw,3.75rem);border:1px solid rgba(244,193,110,.28);border-radius:36px;background: linear-gradient(150deg, rgba(34, 18, 8, 0.92), rgba(16, 8, 6, 0.88));box-shadow:0 32px 80px rgba(8,6,16,.65);backdrop-filter:blur(14px);}
 .mission-ethos__content{color:#f4efe6;display:flex;flex-direction:column;gap:1.35rem;}
 .mission-ethos__eyebrow{display:inline-flex;align-items:center;gap:.75rem;font-size:.85rem;font-weight:600;letter-spacing:.32em;text-transform:uppercase;color:var(--gold,#f4c16e);opacity:.9;}
 .mission-ethos__eyebrow::before{content:"";display:inline-block;width:38px;height:2px;background:linear-gradient(90deg,rgba(244,193,110,.85),rgba(244,193,110,0));}
@@ -2539,15 +2539,17 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .mission-ethos__paragraph--closing{margin-top:.65rem;font-size:1.12rem;color:#fff2dc;font-weight:600;letter-spacing:.01em;}
 .mission-ethos__callout{position:relative;margin:0;padding:1.15rem 1.4rem;border:1px solid rgba(244,193,110,.5);border-radius:18px;background:linear-gradient(135deg,rgba(33,25,46,.92) 0%,rgba(20,18,30,.9) 100%);font-size:1.05rem;font-weight:600;color:#ffe5b8;letter-spacing:.04em;max-width:32ch;box-shadow:0 18px 44px rgba(6,4,12,.55);}
 .mission-ethos__callout::before{content:"";position:absolute;inset:0;border-radius:inherit;border:1px solid rgba(163,119,255,.22);mask:linear-gradient(#fff,#fff) content-box,linear-gradient(#fff,#fff);mask-composite:exclude;padding:1px;}
-.mission-ethos__media{position:relative;display:flex;justify-content:center;align-items:center;}
-.mission-ethos__frame{position:relative;border-radius:28px;overflow:hidden;border: 1px solid rgba(255, 223, 155, .28);box-shadow:0 24px 60px rgba(12,6,24,.65);max-width:100%;background:rgba(16,12,24,.6);}
+.mission-ethos__media{position:relative;display:flex;justify-content:center;align-items:stretch;height:100%;}
+.mission-ethos__frame{position:relative;display:flex;width:100%;height:100%;border-radius:28px;overflow:hidden;border: 1px solid rgba(255, 223, 155, .28);box-shadow:0 24px 60px rgba(12,6,24,.65);max-width:100%;background:rgba(16,12,24,.6);}
 .mission-ethos__frame::after{content:"";position:absolute;inset:12px;border-radius:20px;pointer-events:none;}
-.mission-ethos__frame img{display:block;width:100%;height:auto;object-fit:cover;filter:saturate(1.05) contrast(1.02);}
+.mission-ethos__frame img{display:block;width:100%;height:100%;object-fit:cover;filter:saturate(1.05) contrast(1.02);}
 .mission-ethos__media-note{display:block;margin-top:1.1rem;font-size:.78rem;letter-spacing:.24em;text-transform:uppercase;text-align:center;color:rgba(244,233,212,.72);}
 
 @media (max-width:1100px){
   .mission-ethos__inner{grid-template-columns:minmax(0,1fr);padding:3rem clamp(1.25rem,4vw,2.5rem);gap:2.75rem;}
-  .mission-ethos__media{order:-1;}
+  .mission-ethos__media{order:-1;height:auto;}
+  .mission-ethos__frame{height:auto;}
+  .mission-ethos__frame img{height:auto;}
   .mission-ethos__content{max-width:none;}
 }
 


### PR DESCRIPTION
## Summary
- stretch the mission ethos grid so the media column matches the text column height
- allow the media frame and image to fill the available height while reverting to natural sizing on narrow viewports

## Testing
- Manual QA

------
https://chatgpt.com/codex/tasks/task_e_68da92fb74a0832aaca67f820061badd