### PR TITLE
Align mission memes artwork with adjacent content

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2563,6 +2563,12 @@ section .section-sub{color:var(--muted);max-width:900px;margin:0 0 28px}
 .mission-memes__note{margin:0;font-size:clamp(16px,1.8vw,20px);line-height:1.6;color:rgba(240,204,132,0.86)}
 .mission-memes__hashtags{display:flex;flex-wrap:wrap;gap:12px;margin:0;padding:0;list-style:none;font-family:'Cinzel',serif;font-size:12px;letter-spacing:.24em;text-transform:uppercase;color:rgba(240,204,132,0.72)}
 .mission-memes__hashtags li{padding:8px 18px;border-radius:999px;background:rgba(38,18,8,0.5);border:1px solid rgba(240,204,132,0.32)}
+@media (min-width:1025px){
+  .mission-memes__layout{align-items:stretch}
+  .mission-memes__art{height:100%;grid-template-rows:1fr auto}
+  .mission-memes__frame{height:100%;display:flex}
+  .mission-memes__frame img{flex:1;height:100%}
+}
 @media (max-width:1024px){
   .mission-memes__layout{grid-template-columns:minmax(0,1fr)}
   .mission-memes__art{order:-1}


### PR DESCRIPTION
## Summary
- stretch the mission memes artwork container so it matches the height of the adjacent copy on wide screens
- allow the framed image to fill the available vertical space while retaining the existing mobile stacking layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daa4614054832a877038dc5f154db3